### PR TITLE
fix: manifest.json for dxt

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -100,14 +100,6 @@
       "required": false
     }
   },
-  "platforms": ["darwin", "linux", "win32"],
-  "capabilities": {
-    "tools": true,
-    "resources": false,
-    "prompts": true,
-    "sampling": false
-  },
-  "categories": ["productivity", "project-management", "development", "time-tracking"],
   "keywords": [
     "clickup",
     "mcp",


### PR DESCRIPTION
Hi from Anthropic! Solid work, there were just three invalid keys in the object. I've removed them:
```
dxt pack .
Validating manifest...
ERROR: Manifest validation failed:

  - Unrecognized key(s) in object: 'platforms', 'capabilities', 'categories'
ERROR: Cannot pack extension with invalid manifest
```