### PR TITLE
fix: implement dedicated tag management endpoints for ClickUp tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed tag management in `updateTask` - tags are now properly added/removed using dedicated API endpoints
+  - The ClickUp API doesn't support updating tags via the general update endpoint
+  - `updateTask` now internally handles tag changes by calling the appropriate add/remove endpoints
+  - Compares current tags with requested tags to determine which to add or remove
+  - Maintains single tool interface while properly managing tags behind the scenes
+
 ## [1.4.0] - 2025-08-18
 
 ### Added


### PR DESCRIPTION
Fixes #4  

The ClickUp API doesn't support updating tags through the general updateTask endpoint. Tags must be managed using dedicated API endpoints for adding and removing tags individually.

Changes:
- Add new `addTagToTask` MCP tool using POST /task/{task_id}/tag/{tag_name}
- Add new `removeTagFromTask` MCP tool using DELETE /task/{task_id}/tag/{tag_name}
- Deprecate tags parameter in `updateTask` with clear documentation
- Update manifest.json to register the new MCP tools
- Add proper error handling and user feedback for tag operations

This fixes the issue where tags added via MCP were not being attached to tasks, as reported when using pre-defined tags with the updateTask endpoint.

Fixes tag management functionality to align with ClickUp API requirements.

## Testing                                                                                                                                                                                                                       
   The changes have been tested locally with the following scenarios:                                                                                                                                                               
   - ✅ Adding tags to tasks using the new `addTagToTask` tool                                                                                                                                                                       
   - ✅ Removing tags from tasks using the new `removeTagFromTask` tool                                                                                                                                                              
   - ✅ Verifying deprecation warning when using `tags` parameter in `updateTask`                                                                                                                                                    
   - ✅ Confirming tags appear correctly in the ClickUp UI                                                                                                                                                                           
                                                                                                                                                                                                                                    
   ## Usage Example                                                                                                                                                                                                                 
   Instead of:                                                                                                                                                                                                                      
   ```javascript                                                                                                                                                                                                                    
   updateTask(task_id: "86c4zp7xx", tags: ["ux", "refinement"])                                                                                                                                                                     
   ```                                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
   Now use:                                                                                                                                                                                                                         
   ```javascript                                                                                                                                                                                                                    
   addTagToTask(task_id: "86c4zp7xx", tag_name: "refinement")                                                                                                                                                                       
   removeTagFromTask(task_id: "86c4zp7xx", tag_name: "old-tag")                                                                                                                                                                     
   ```                                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
   ## Breaking Changes                                                                                                                                                                                                              
   None. The `updateTask` function still accepts the `tags` parameter but will log a warning and not process the tags. sers hould migrate to using the new dedicated functions.                                                   │
                                                                                                                                                                                                                                    
   ## References                                                                                                                                                                                                                    
   - [ClickUp API Documentation - Add Tag to Task](https://developer.clickup.com/reference/addtagtotask)                                                                                                                            
   - [ClickUp API Documentation - Remove Tag from Task](https://developer.clickup.com/reference/removetagfromtask)