### PR TITLE
Expand mocked API tests for ClickUp MCP tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hauptsache.net/clickup-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hauptsache.net/clickup-mcp",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",
@@ -21,10 +21,53 @@
         "dotenv": "^16.5.0",
         "nodemon": "^3.1.9",
         "prettier": "^3.5.3",
-        "typescript": "^5.8.3"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3",
+        "undici": "^7.16.0"
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -50,6 +93,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
@@ -71,6 +142,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -102,6 +199,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -289,6 +393,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -327,6 +438,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {
@@ -796,6 +917,13 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1361,6 +1489,50 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1396,6 +1568,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -1420,6 +1602,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -1450,6 +1639,16 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/zod": {
       "version": "3.24.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prettier": "prettier --write src/**/*.ts",
     "prepublishOnly": "rm -r dist && npm run build",
     "release": "npm run build && npm publish --access public && git add . && git commit -m \"Release v$(node -p 'require(\"./package.json\").version')\" && git tag -a v$(node -p 'require(\"./package.json\").version') -m \"Release v$(node -p 'require(\"./package.json\").version')\" && git push && git push --tags",
-    "dxt": "npm run build && npx dxt pack"
+    "dxt": "npm run build && npx dxt pack",
+    "test": "node --test -r ts-node/register src/**/*.test.ts"
   },
   "keywords": [
     "clickup",
@@ -48,7 +49,9 @@
     "dotenv": "^16.5.0",
     "nodemon": "^3.1.9",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.3"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3",
+    "undici": "^7.16.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/src/tests/addComment.test.ts
+++ b/src/tests/addComment.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("addComment posts comment to task", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerTaskToolsWrite } = await import("../tools/task-write-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  let bodyCaptured: any;
+  client
+    .intercept({ path: "/api/v2/task/task123/comment", method: "POST" })
+    .reply((opts) => {
+      bodyCaptured = JSON.parse(String(opts.body));
+      return { statusCode: 200, data: { id: "c1", user: { username: "me" }, date: "0" } };
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerTaskToolsWrite(serverStub, { user: { username: "me", id: "u1" } });
+
+  const result = await tools.addComment({ task_id: "task123", comment: "Nice" });
+
+  assert.equal(bodyCaptured.comment_text, "Nice");
+  assert.equal(bodyCaptured.notify_all, true);
+  assert.ok(result.content[0].text.includes("Comment added successfully"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});

--- a/src/tests/createTask.test.ts
+++ b/src/tests/createTask.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("createTask posts task with defaults", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerTaskToolsWrite } = await import("../tools/task-write-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/user", method: "GET" })
+    .reply(200, { user: { id: "u1", username: "me" } });
+
+  let bodyCaptured: any;
+  client
+    .intercept({ path: "/api/v2/list/list123/task", method: "POST" })
+    .reply((opts) => {
+      bodyCaptured = JSON.parse(String(opts.body));
+      return { statusCode: 200, data: { id: "task999", name: "New Task", status: { status: "open" }, assignees: [{ id: "u1", username: "me" }], url: "https://app.clickup.com/t/task999" } };
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerTaskToolsWrite(serverStub, { user: { username: "me", id: "u1" } });
+
+  const result = await tools.createTask({ list_id: "list123", name: "New Task", description: "Desc" });
+
+  assert.equal(bodyCaptured.name, "New Task");
+  assert.equal(bodyCaptured.markdown_description, "Desc");
+  assert.deepEqual(bodyCaptured.assignees, ["u1"]);
+  assert.ok(result.content[0].text.includes("Task created successfully"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});

--- a/src/tests/createTimeEntry.test.ts
+++ b/src/tests/createTimeEntry.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("createTimeEntry posts correct body", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerTimeToolsWrite } = await import("../tools/time-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  let bodyCaptured: any;
+  client
+    .intercept({ path: "/api/v2/team/team1/time_entries", method: "POST" })
+    .reply((opts) => {
+      bodyCaptured = JSON.parse(String(opts.body));
+      return { statusCode: 200, data: { data: { id: "e1", user: { username: "me" } } } };
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerTimeToolsWrite(serverStub);
+
+  const result = await tools.createTimeEntry({ task_id: "task1", hours: 2, description: "Work" });
+
+  assert.equal(bodyCaptured.tid, "task1");
+  assert.equal(bodyCaptured.duration, 2 * 60 * 60 * 1000);
+  assert.ok(result.content[0].text.includes("Time entry created successfully"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});

--- a/src/tests/getListInfo.test.ts
+++ b/src/tests/getListInfo.test.ts
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("getListInfo fetches list details and space tags", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerListToolsRead } = await import("../tools/list-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({
+      path: "/api/v2/list/list123?include_markdown_description=true",
+      method: "GET",
+    })
+    .reply(200, {
+      id: "list123",
+      name: "My List",
+      folder: { name: "FolderA" },
+      space: { id: "space1", name: "SpaceA" },
+      archived: false,
+      task_count: 0,
+      markdown_description: "description",
+      statuses: [
+        { status: "Open", type: "open" },
+        { status: "Closed", type: "done" },
+      ],
+    });
+
+  client
+    .intercept({ path: "/api/v2/space/space1/tag", method: "GET" })
+    .reply(200, { tags: [{ name: "tag1" }] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerListToolsRead(serverStub);
+
+  const result = await tools.getListInfo({ list_id: "list123" });
+  assert.ok(result.content[0].text.includes("list_id: list123"));
+  assert.ok(result.content[0].text.includes("Available statuses"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tests/getTaskById.test.ts
+++ b/src/tests/getTaskById.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MockAgent, setGlobalDispatcher } from 'undici';
+
+// Helper to register tool and call handler
+
+test('getTaskById makes correct API calls', async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = 'test-key';
+  process.env.CLICKUP_TEAM_ID = 'team1';
+
+  const { registerTaskToolsRead } = await import('../tools/task-tools');
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get('https://api.clickup.com');
+
+  client.intercept({ path: '/api/v2/team', method: 'GET' })
+    .reply(200, { teams: [{ id: 'team1', members: [] }] });
+
+  client.intercept({ path: /\/api\/v2\/task\/task123.*/, method: 'GET' })
+    .reply(200, {
+      id: 'task123',
+      name: 'Test Task',
+      markdown_description: '',
+      attachments: [],
+      creator: { username: 'creator', id: '1' },
+      assignees: [],
+      list: { id: 'list1', name: 'List' },
+      space: { id: 'space1', name: 'Space' },
+      status: { status: 'open', type: 'open' },
+      url: 'https://app.clickup.com/t/task123',
+      date_created: '0',
+      date_updated: '0'
+    });
+
+  client.intercept({ path: /\/api\/v2\/task\/task123\/comment.*/, method: 'GET' })
+    .reply(200, { comments: [] });
+
+  client.intercept({ path: '/api/v2/task/task123/time_in_status', method: 'GET' })
+    .reply(200, { status_history: [], current_status: null });
+
+  client.intercept({ path: /\/api\/v2\/team\/team1\/time_entries.*/, method: 'GET' })
+    .reply(200, { data: [] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (name: string, _desc: string, _schema: any, _opts: any, handler: any) => {
+      tools[name] = handler;
+    }
+  } as any;
+
+  registerTaskToolsRead(serverStub, { user: { username: 'me', id: 'u1' } });
+
+  const result = await tools.getTaskById({ id: 'task123' });
+  assert.ok(result.content.some((block: any) =>
+    typeof block.text === 'string' && block.text.includes('task_id: task123')
+  ));
+
+  (mockAgent as any).assertNoPendingInterceptors();
+  await mockAgent.close();
+  t.mock.timers.reset();
+});
+

--- a/src/tests/getTimeEntries.test.ts
+++ b/src/tests/getTimeEntries.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("getTimeEntries requests time entries for task", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerTimeToolsRead } = await import("../tools/time-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({
+      path: /\/api\/v2\/team\/team1\/time_entries\?.*task_id=task1.*/,
+      method: "GET",
+    })
+    .reply(200, { data: [] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerTimeToolsRead(serverStub);
+
+  const result = await tools.getTimeEntries({ task_id: "task1" });
+  assert.ok(result.content[0].text.includes("Time Entries Summary"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tests/readDocument.test.ts
+++ b/src/tests/readDocument.test.ts
@@ -1,0 +1,59 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("readDocument fetches document and page content", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerDocumentToolsRead } = await import("../tools/doc-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v3/workspaces/team1/docs/doc123", method: "GET" })
+    .reply(200, { id: "doc123", name: "Doc Title" });
+
+  client
+    .intercept({
+      path: "/api/v3/workspaces/team1/docs/doc123/pageListing",
+      method: "GET",
+    })
+    .reply(200, [
+      { id: "page1", name: "Page One", doc_id: "doc123", pages: [] },
+    ]);
+
+  client
+    .intercept({
+      path: "/api/v3/workspaces/team1/docs/doc123/pages/page1",
+      method: "GET",
+    })
+    .reply(200, { id: "page1", name: "Page One", content: "Hello" });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerDocumentToolsRead(serverStub);
+
+  const result = await tools.readDocument({ doc_id: "doc123" });
+  const text = result.content.map((b: any) => b.text || "").join("\n");
+  assert.ok(text.includes("doc_id: doc123"));
+  assert.ok(text.includes("Page Content"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tests/searchDocuments.test.ts
+++ b/src/tests/searchDocuments.test.ts
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("searchDocuments returns matching documents", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerDocumentToolsRead } = await import("../tools/doc-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/team/team1/space", method: "GET" })
+    .reply(200, { spaces: [{ id: "s1", name: "Space" }] });
+
+  client
+    .intercept({ path: /\/api\/v3\/workspaces\/team1\/docs.*/, method: "GET" })
+    .reply(200, { docs: [{ id: "doc1", name: "Spec", parent: { type: 4, id: "s1" }, date_created: "0" }] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerDocumentToolsRead(serverStub);
+
+  const result = await tools.searchDocuments({ terms: ["Spec"] });
+  const text = result.content.map((b: any) => b.text || "").join("\n");
+  assert.ok(text.includes("Spec"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});

--- a/src/tests/searchSpaces.test.ts
+++ b/src/tests/searchSpaces.test.ts
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("searchSpaces fetches spaces and related content", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerSpaceTools } = await import("../tools/space-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/team/team1/space", method: "GET" })
+    .reply(200, {
+      spaces: [
+        { id: "s1", name: "Alpha", archived: false },
+        { id: "s2", name: "Beta", archived: false },
+      ],
+    });
+
+  // Content fetches for space s1 (only matching space)
+  client
+    .intercept({ path: "/api/v2/space/s1/folder", method: "GET" })
+    .reply(200, { folders: [] });
+  client
+    .intercept({ path: "/api/v2/space/s1/list", method: "GET" })
+    .reply(200, { lists: [] });
+  client
+    .intercept({
+      path: "/api/v3/workspaces/team1/docs?parent_id=s1",
+      method: "GET",
+    })
+    .reply(200, { docs: [] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerSpaceTools(serverStub);
+
+  const result = await tools.searchSpaces({ terms: ["Alpha"] });
+  const text = result.content.map((b: any) => b.text || "").join("\n");
+  assert.ok(text.includes("SPACE: Alpha"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tests/searchTasks.test.ts
+++ b/src/tests/searchTasks.test.ts
@@ -1,0 +1,212 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("searchTasks fetches missing task by id", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerSearchTools } = await import("../tools/search-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  // Task index requests
+  client
+    .intercept({ path: /\/api\/v2\/team\/team1\/task.*/, method: "GET" })
+    .reply(200, { tasks: [] })
+    .persist();
+
+  // Direct fetch for task id not found in index
+  let directHit = false;
+  client
+    .intercept({ path: "/api/v2/task/abc123", method: "GET" })
+    .reply(200, () => {
+      directHit = true;
+      return {
+        id: "abc123",
+        name: "Fetched Task",
+        creator: { username: "creator", id: "1" },
+        assignees: [],
+        list: { id: "list1", name: "List" },
+        space: { id: "space1", name: "Space" },
+        status: { status: "open", type: "open" },
+        url: "https://app.clickup.com/t/abc123",
+        date_created: "0",
+        date_updated: "0",
+      };
+    });
+
+  // Time entry helper calls
+  client
+    .intercept({ path: "/api/v2/team", method: "GET" })
+    .reply(200, { teams: [{ id: "team1", members: [] }] });
+
+  client
+    .intercept({
+      path: /\/api\/v2\/team\/team1\/time_entries.*/,
+      method: "GET",
+    })
+    .reply(200, { data: [] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerSearchTools(serverStub, { user: { username: "me", id: "u1" } });
+
+  const result = await tools.searchTasks({ terms: ["abc123"] });
+  assert.ok(directHit, "expected direct task fetch");
+  assert.ok(result.content[0].text.includes("task_id: abc123"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});
+
+test("searchTasks uses paginated index with filters", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerSearchTools } = await import("../tools/search-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  // Paginated task index - two pages of results
+  let page0Hit = false;
+  let page1Hit = false;
+  client
+    .intercept({ path: /\/api\/v2\/team\/team1\/task.*page=0/, method: "GET" })
+    .reply(200, () => {
+      page0Hit = true;
+      const base = {
+        creator: { username: "creator", id: "1" },
+        assignees: [],
+        list: { id: "list1", name: "List" },
+        space: { id: "space1", name: "Space 1" },
+        status: { status: "open", type: "open" },
+        date_created: "0",
+        date_updated: "0",
+      };
+      return {
+        tasks: [
+          {
+            ...base,
+            id: "t1",
+            name: "Bug report",
+            url: "https://app.clickup.com/t/t1",
+          },
+          {
+            ...base,
+            id: "t2",
+            name: "Feature request",
+            url: "https://app.clickup.com/t/t2",
+          },
+          {
+            ...base,
+            id: "t3",
+            name: "Another bug",
+            url: "https://app.clickup.com/t/t3",
+          },
+        ],
+      };
+    });
+
+  client
+    .intercept({ path: /\/api\/v2\/team\/team1\/task.*page=1/, method: "GET" })
+    .reply(200, () => {
+      page1Hit = true;
+      const base = {
+        creator: { username: "creator", id: "1" },
+        assignees: [],
+        list: { id: "list1", name: "List" },
+        space: { id: "space1", name: "Space 1" },
+        status: { status: "open", type: "open" },
+        date_created: "0",
+        date_updated: "0",
+      };
+      return {
+        tasks: [
+          {
+            ...base,
+            id: "t4",
+            name: "Bugfix followup",
+            url: "https://app.clickup.com/t/t4",
+          },
+          {
+            ...base,
+            id: "t5",
+            name: "Chore",
+            url: "https://app.clickup.com/t/t5",
+          },
+        ],
+      };
+    });
+
+  // Remaining pages return empty arrays
+  client
+    .intercept({ path: /\/api\/v2\/team\/team1\/task.*/, method: "GET" })
+    .reply(200, { tasks: [] })
+    .persist();
+
+  // Time entry helper calls
+  client
+    .intercept({ path: "/api/v2/team", method: "GET" })
+    .reply(200, { teams: [{ id: "team1", members: [] }] });
+
+  client
+    .intercept({
+      path: /\/api\/v2\/team\/team1\/time_entries.*list_id=list1/,
+      method: "GET",
+    })
+    .reply(200, { data: [] });
+
+  client
+    .intercept({ path: "/api/v2/space/space1", method: "GET" })
+    .reply(200, { id: "space1", name: "Space 1" });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerSearchTools(serverStub, { user: { username: "me", id: "u1" } });
+
+  const result = await tools.searchTasks({
+    terms: ["bug"],
+    list_ids: ["list1"],
+    space_ids: ["space1"],
+  });
+
+  assert.ok(page0Hit && page1Hit, "expected to fetch multiple pages");
+  const combinedText = result.content.map((b: any) => b.text || "").join("\n");
+  assert.ok(combinedText.includes("task_id: t1"));
+  assert.ok(combinedText.includes("task_id: t3"));
+  assert.ok(combinedText.includes("task_id: t4"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tests/updateListInfo.test.ts
+++ b/src/tests/updateListInfo.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("updateListInfo appends description", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerListToolsWrite } = await import("../tools/list-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/list/list123?include_markdown_description=true", method: "GET" })
+    .reply(200, { id: "list123", name: "List", markdown_description: "existing" });
+
+  let bodyCaptured: any;
+  client
+    .intercept({ path: "/api/v2/list/list123", method: "PUT" })
+    .reply((opts) => {
+      bodyCaptured = JSON.parse(String(opts.body));
+      return { statusCode: 200, data: {} };
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerListToolsWrite(serverStub);
+
+  const result = await tools.updateListInfo({ list_id: "list123", append_description: "Extra" });
+
+  assert.ok(bodyCaptured.markdown_content.includes("Extra"));
+  assert.ok(bodyCaptured.markdown_content.includes("**Edit ("));
+  assert.ok(result.content[0].text.includes("Successfully appended content"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});

--- a/src/tests/updateTask.test.ts
+++ b/src/tests/updateTask.test.ts
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("updateTask updates name and description", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerTaskToolsWrite } = await import("../tools/task-write-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/user", method: "GET" })
+    .reply(200, { user: { id: "u1", username: "me" } });
+
+  client
+    .intercept({ path: "/api/v2/task/task123?include_markdown_description=true", method: "GET" })
+    .reply(200, { id: "task123", name: "Old", markdown_description: "existing", status: { status: "open", type: "open" }, assignees: [], url: "https://app.clickup.com/t/task123" });
+
+  let bodyCaptured: any;
+  client
+    .intercept({ path: "/api/v2/task/task123", method: "PUT" })
+    .reply((opts) => {
+      bodyCaptured = JSON.parse(String(opts.body));
+      return { statusCode: 200, data: { id: "task123", name: "New Name", status: { status: "open", type: "open" }, assignees: [], url: "https://app.clickup.com/t/task123" } };
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerTaskToolsWrite(serverStub, { user: { username: "me", id: "u1" } });
+
+  const result = await tools.updateTask({ task_id: "task123", name: "New Name", append_description: "More details" });
+
+  assert.equal(bodyCaptured.name, "New Name");
+  assert.ok(bodyCaptured.markdown_description.includes("More details"));
+  assert.ok(result.content[0].text.includes("Task updated successfully"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});

--- a/src/tests/writeDocument.test.ts
+++ b/src/tests/writeDocument.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("writeDocument updates existing page", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerDocumentToolsWrite } = await import("../tools/doc-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  let bodyCaptured: any;
+  client
+    .intercept({ path: "/api/v3/docs/pages/page1", method: "PUT" })
+    .reply((opts) => {
+      bodyCaptured = JSON.parse(String(opts.body));
+      return { statusCode: 200, data: { page: { id: "page1", name: "Updated", doc_id: "doc123" } } };
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerDocumentToolsWrite(serverStub);
+
+  const result = await tools.writeDocument({ page_id: "page1", page_name: "Updated", content: "Hello" });
+
+  assert.equal(bodyCaptured.name, "Updated");
+  assert.equal(bodyCaptured.content, "Hello");
+  assert.ok(result.content[0].text.includes("Successfully updated page"));
+
+  await mockAgent.close();
+  t.mock.timers.runAll();
+  t.mock.timers.reset();
+});


### PR DESCRIPTION
## Summary
- extend coverage with mocked API tests for remaining MCP tools

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c76459ca94832fa3b8f8cec3d8d559