### PR TITLE
docs: add Factory installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,27 @@ env = { "CLICKUP_API_KEY" = "YOUR_KEY", "CLICKUP_TEAM_ID" = "YOUR_ID", "CLICKUP_
 
 > Note the `CLICKUP_MCP_MODE=read-minimal`. This is my usage recommendation, but feel free to use one of the other modes.
 
+**Factory:**
+
+[Factory](https://factory.ai) is an AI-powered software engineering platform. Add ClickUp MCP using Factory's CLI:
+
+```bash
+droid mcp add clickup "npx -y @hauptsache.net/clickup-mcp@latest" \
+  --env CLICKUP_API_KEY=YOUR_KEY \
+  --env CLICKUP_TEAM_ID=YOUR_ID \
+  --env CLICKUP_MCP_MODE=read-minimal \
+  --env MAX_IMAGES=16 \
+  --env MAX_RESPONSE_SIZE_MB=4
+```
+
+Alternatively, type `/mcp` within Factory droid to open an interactive UI for managing MCP servers.
+
+> Factory can handle extensive image context, thus the recommended increased limits.
+
+> Note the `CLICKUP_MCP_MODE=read-minimal`. This is recommended for coding workflows, but feel free to use one of the other modes.
+
+Learn more about Factory's MCP configuration in the [Factory documentation](https://docs.factory.ai/cli/configuration/mcp).
+
 ## MCP Modes & Available Tools
 
 The ClickUp MCP supports three operational modes to balance functionality, security, and performance:


### PR DESCRIPTION
This PR adds Factory as an installation option under **Option 3: Coding Tools Integration**.

## Changes

Adds a new **Factory** section that includes:

### CLI Installation
- Command: `droid mcp add clickup "npx -y @hauptsache.net/clickup-mcp@latest"`
- Recommended environment variables including `CLICKUP_API_KEY`, `CLICKUP_TEAM_ID`, and `CLICKUP_MCP_MODE`
- Increased limits for image handling (`MAX_IMAGES=16`, `MAX_RESPONSE_SIZE_MB=4`) since Factory can handle extensive image context

### Interactive UI Option
- Instructions for using Factory's `/mcp` command to access an interactive UI for managing MCP servers

### Configuration Notes
- Recommends `read-minimal` mode for coding workflows (consistent with other tools)
- Explains the rationale for increased limits
- Links to Factory documentation at https://docs.factory.ai/cli/configuration/mcp

## About Factory

[Factory](https://factory.ai) is an AI-powered software engineering platform that supports MCP servers through both CLI commands and an interactive UI.

This follows the same pattern and structure as the existing installation instructions for Claude Code and OpenAI Codex in the coding tools integration section.