### PR TITLE
Add time entry description to output display

### DIFF
--- a/src/tools/time-tools.ts
+++ b/src/tools/time-tools.ts
@@ -301,7 +301,8 @@ function processTimeEntriesData(data: any, task_id?: string, start_date?: string
               entryDuration = formatDuration(rawDuration);
             }
             
-            outputLines.push(`${entryPrefix} ${entryStart} - ${entryDuration}`);
+            const entryDescription = entry.description ? ` | ${entry.description}` : '';
+            outputLines.push(`${entryPrefix} ${entryStart} - ${entryDuration}${entryDescription}`);
           });
         }
       }


### PR DESCRIPTION
When users track time on generic/shared tasks (e.g. a "Meetings" task), the description field on individual time entries is the only way to distinguish what each entry was actually about. Previously, time entry descriptions were fetched from the API but never displayed in the output.

This PR appends the time entry description (when available) to the output line, separated by a pipe:

```
2026-01-09 15:46 - 1h 0m | Project sync meeting
```

  This is particularly useful for:
  - **Generic tasks** like "Meetings" or "Support" where multiple distinct activities are logged under the same task
  - **Daily reporting** where seeing the description gives immediate context without having to open each time entry individually