### PR TITLE
Add getFolderInfo tool to retrieve folder details by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `getFolderInfo` tool to get folder details (name, lists, parent space, statuses) by folder ID
 - Added comparison table in README showing differences between this MCP and the official ClickUp MCP
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,10 @@
       "description": "Get comprehensive information about a list including description, available statuses, space tags, and project context for task creation."
     },
     {
+      "name": "getFolderInfo",
+      "description": "Get information about a ClickUp folder including its lists, parent space, statuses, and metadata."
+    },
+    {
       "name": "updateListInfo",
       "description": "Append documentation or context to a list's description (append-only for safety) with markdown support and timestamp tracking."
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { registerTaskToolsRead } from "./tools/task-tools";
 import { registerTaskToolsWrite } from "./tools/task-write-tools";
 import { registerSearchTools } from "./tools/search-tools";
 import { registerSpaceTools } from "./tools/space-tools";
-import { registerListToolsRead, registerListToolsWrite } from "./tools/list-tools";
+import { registerListToolsRead, registerListToolsWrite, registerFolderToolsRead } from "./tools/list-tools";
 import { registerTimeToolsRead, registerTimeToolsWrite } from "./tools/time-tools";
 import { registerDocumentToolsRead, registerDocumentToolsWrite } from "./tools/doc-tools";
 import { registerSpaceResources } from "./resources/space-resources";
@@ -110,6 +110,7 @@ Use the ClickUp search tools to find tasks assigned to me, and get detailed info
     registerSpaceTools(server);
     registerSpaceResources(server);
     registerListToolsRead(server);
+    registerFolderToolsRead(server);
     registerTimeToolsRead(server);
     registerDocumentToolsRead(server);
   } else if (CONFIG.mode === 'write') {
@@ -121,6 +122,7 @@ Use the ClickUp search tools to find tasks assigned to me, and get detailed info
     registerSpaceResources(server);
     registerListToolsRead(server);
     registerListToolsWrite(server);
+    registerFolderToolsRead(server);
     registerTimeToolsRead(server);
     registerTimeToolsWrite(server);
     registerDocumentToolsRead(server);

--- a/src/tests/getFolderInfo.test.ts
+++ b/src/tests/getFolderInfo.test.ts
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("getFolderInfo fetches folder details and lists", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerFolderToolsRead } = await import("../tools/list-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({
+      path: "/api/v2/folder/folder123",
+      method: "GET",
+    })
+    .reply(200, {
+      id: "folder123",
+      name: "My Folder",
+      space: { id: "space1", name: "SpaceA" },
+      archived: false,
+      hidden: false,
+      lists: [
+        { id: "list1", name: "List One", task_count: 5, archived: false },
+        { id: "list2", name: "List Two", task_count: 0, archived: true },
+      ],
+      statuses: [
+        { status: "Open", type: "open" },
+        { status: "In Progress", type: "custom" },
+        { status: "Closed", type: "closed" },
+      ],
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerFolderToolsRead(serverStub);
+
+  const result = await tools.getFolderInfo({ folder_id: "folder123" });
+  const text = result.content[0].text;
+  assert.ok(text.includes("folder_id: folder123"));
+  assert.ok(text.includes("name: My Folder"));
+  assert.ok(text.includes("space: SpaceA (space_id: space1)"));
+  assert.ok(text.includes("Lists in this folder (2 total)"));
+  assert.ok(text.includes("List One (list_id: list1, 5 tasks)"));
+  assert.ok(text.includes("List Two (list_id: list2, archived)"));
+  assert.ok(text.includes("Available statuses (3 total)"));
+  assert.ok(text.includes("Open (open)"));
+  assert.ok(text.includes("In Progress (custom)"));
+  assert.ok(text.includes("Closed (closed)"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tools/list-tools.ts
+++ b/src/tools/list-tools.ts
@@ -1,7 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { CONFIG } from "../shared/config";
-import { generateListUrl, generateSpaceUrl } from "../shared/utils";
+import {
+  generateListUrl,
+  generateSpaceUrl,
+  generateFolderUrl,
+  getFolderDetails,
+} from "../shared/utils";
 
 export function registerListToolsRead(server: McpServer) {
   server.tool(
@@ -11,23 +16,28 @@ export function registerListToolsRead(server: McpServer) {
       "ALWAYS use the list URL (https://app.clickup.com/v/l/LIST_ID) when referencing lists.",
       "Use this before creating tasks to understand the list context and available statuses for new tasks.",
       "IMPORTANT: The list description often contains valuable project context, requirements, or guidelines - read and consider this information when creating or updating tasks in this list.",
-      "Share the clickable list URL when suggesting list-related actions."
+      "Share the clickable list URL when suggesting list-related actions.",
     ].join("\n"),
     {
-      list_id: z.string().min(1).describe("The list ID to get information for")
+      list_id: z.string().min(1).describe("The list ID to get information for"),
     },
     {
-      readOnlyHint: true
+      readOnlyHint: true,
     },
     async ({ list_id }) => {
       try {
         // Get list details including statuses (try to get markdown content)
-        const listResponse = await fetch(`https://api.clickup.com/api/v2/list/${list_id}?include_markdown_description=true`, {
-          headers: { Authorization: CONFIG.apiKey },
-        });
+        const listResponse = await fetch(
+          `https://api.clickup.com/api/v2/list/${list_id}?include_markdown_description=true`,
+          {
+            headers: { Authorization: CONFIG.apiKey },
+          },
+        );
 
         if (!listResponse.ok) {
-          throw new Error(`Error fetching list details: ${listResponse.status} ${listResponse.statusText}`);
+          throw new Error(
+            `Error fetching list details: ${listResponse.status} ${listResponse.statusText}`,
+          );
         }
 
         const listData = await listResponse.json();
@@ -36,15 +46,21 @@ export function registerListToolsRead(server: McpServer) {
         let spaceTags: any[] = [];
         if (listData.space?.id) {
           try {
-            const spaceTagsResponse = await fetch(`https://api.clickup.com/api/v2/space/${listData.space.id}/tag`, {
-              headers: { Authorization: CONFIG.apiKey },
-            });
+            const spaceTagsResponse = await fetch(
+              `https://api.clickup.com/api/v2/space/${listData.space.id}/tag`,
+              {
+                headers: { Authorization: CONFIG.apiKey },
+              },
+            );
             if (spaceTagsResponse.ok) {
               const spaceTagsData = await spaceTagsResponse.json();
               spaceTags = spaceTagsData.tags || [];
             }
           } catch (error) {
-            console.error(`Error fetching space tags for space ${listData.space.id}:`, error);
+            console.error(
+              `Error fetching space tags for space ${listData.space.id}:`,
+              error,
+            );
           }
         }
 
@@ -53,15 +69,18 @@ export function registerListToolsRead(server: McpServer) {
           `list_id: ${list_id}`,
           `list_url: ${generateListUrl(list_id)}`,
           `name: ${listData.name}`,
-          `folder: ${listData.folder?.name || 'No folder'}`,
-          `space: ${listData.space?.name || 'Unknown'} (${listData.space?.id || 'N/A'})`,
-          `space_url: ${generateSpaceUrl(listData.space?.id || '')}`,
+          `folder: ${listData.folder?.name || "No folder"}`,
+          `space: ${listData.space?.name || "Unknown"} (${listData.space?.id || "N/A"})`,
+          `space_url: ${generateSpaceUrl(listData.space?.id || "")}`,
           `archived: ${listData.archived || false}`,
           `task_count: ${listData.task_count || 0}`,
         ];
 
         // Add description if available (check both content and markdown fields)
-        const description = listData.markdown_description || listData.markdown_content || listData.content;
+        const description =
+          listData.markdown_description ||
+          listData.markdown_content ||
+          listData.content;
         if (description) {
           responseLines.push(`description: ${description}`);
         }
@@ -70,8 +89,8 @@ export function registerListToolsRead(server: McpServer) {
         if (listData.statuses && Array.isArray(listData.statuses)) {
           const statuses = listData.statuses.map((status: any) => ({
             name: status.status,
-            color: status.color || 'none',
-            type: status.type || 'custom'
+            color: status.color || "none",
+            type: status.type || "custom",
           }));
 
           responseLines.push(`Available statuses (${statuses.length} total):`);
@@ -80,42 +99,138 @@ export function registerListToolsRead(server: McpServer) {
             responseLines.push(`  - ${status.name} (${status.type})`);
           });
 
-          responseLines.push(`Valid status names for createTask/updateTask: ${statuses.map((s: any) => s.name).join(', ')}`);
+          responseLines.push(
+            `Valid status names for createTask/updateTask: ${statuses.map((s: any) => s.name).join(", ")}`,
+          );
         } else {
-          responseLines.push('No statuses found for this list.');
+          responseLines.push("No statuses found for this list.");
         }
 
         // Add space tags information
         if (spaceTags.length > 0) {
-          const tagNames = spaceTags.map((tag: any) => tag.name).filter(Boolean).sort();
+          const tagNames = spaceTags
+            .map((tag: any) => tag.name)
+            .filter(Boolean)
+            .sort();
           if (tagNames.length > 0) {
-            responseLines.push(`Available tags in space (shared across all lists): ${tagNames.join(', ')}`);
+            responseLines.push(
+              `Available tags in space (shared across all lists): ${tagNames.join(", ")}`,
+            );
           }
         } else if (listData.space?.id) {
-          responseLines.push('No tags found in this space.');
+          responseLines.push("No tags found in this space.");
         }
 
         return {
           content: [
             {
               type: "text" as const,
-              text: responseLines.join('\n')
-            }
+              text: responseLines.join("\n"),
+            },
           ],
         };
-
       } catch (error) {
-        console.error('Error getting list info:', error);
+        console.error("Error getting list info:", error);
         return {
           content: [
             {
               type: "text",
-              text: `Error getting list info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              text: `Error getting list info: ${error instanceof Error ? error.message : "Unknown error"}`,
             },
           ],
         };
       }
-    }
+    },
+  );
+}
+
+export function registerFolderToolsRead(server: McpServer) {
+  server.tool(
+    "getFolderInfo",
+    [
+      "Gets information about a ClickUp folder including its lists, parent space, and metadata.",
+      "ALWAYS use the folder URL (https://app.clickup.com/TEAM_ID/v/f/FOLDER_ID) when referencing folders.",
+      "Use this to discover lists inside a folder or understand folder structure.",
+      "Share the clickable folder URL when suggesting folder-related actions.",
+    ].join("\n"),
+    {
+      folder_id: z
+        .string()
+        .min(1)
+        .describe("The folder ID to get information for"),
+    },
+    {
+      readOnlyHint: true,
+    },
+    async ({ folder_id }) => {
+      try {
+        const folderData = await getFolderDetails(folder_id);
+
+        const responseLines = [
+          `Folder Information:`,
+          `folder_id: ${folder_id}`,
+          `folder_url: ${generateFolderUrl(folder_id)}`,
+          `name: ${folderData.name}`,
+          `space: ${folderData.space?.name || "Unknown"} (space_id: ${folderData.space?.id || "N/A"})`,
+          `space_url: ${generateSpaceUrl(folderData.space?.id || "")}`,
+          `archived: ${folderData.archived || false}`,
+          `hidden: ${folderData.hidden || false}`,
+        ];
+
+        // Add lists contained in this folder
+        if (
+          folderData.lists &&
+          Array.isArray(folderData.lists) &&
+          folderData.lists.length > 0
+        ) {
+          responseLines.push(
+            `Lists in this folder (${folderData.lists.length} total):`,
+          );
+          folderData.lists.forEach((list: any) => {
+            const extraInfo = [
+              ...(list.task_count ? [`${list.task_count} tasks`] : []),
+              ...(list.archived ? ["archived"] : []),
+            ].join(", ");
+            responseLines.push(
+              `  - ${list.name} (list_id: ${list.id}${extraInfo ? `, ${extraInfo}` : ""}) ${generateListUrl(list.id)}`,
+            );
+          });
+        } else {
+          responseLines.push("No lists found in this folder.");
+        }
+
+        // Add available statuses if present
+        if (folderData.statuses && Array.isArray(folderData.statuses)) {
+          const statuses = folderData.statuses.map((status: any) => ({
+            name: status.status,
+            type: status.type || "custom",
+          }));
+          responseLines.push(`Available statuses (${statuses.length} total):`);
+          statuses.forEach((status: any) => {
+            responseLines.push(`  - ${status.name} (${status.type})`);
+          });
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: responseLines.join("\n"),
+            },
+          ],
+        };
+      } catch (error) {
+        console.error("Error getting folder info:", error);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error getting folder info: ${error instanceof Error ? error.message : "Unknown error"}`,
+            },
+          ],
+        };
+      }
+    },
   );
 }
 
@@ -128,11 +243,16 @@ export function registerListToolsWrite(server: McpServer) {
       "SAFETY FEATURE: Description updates are APPEND-ONLY to prevent data loss - existing content is preserved.",
       "Use this to add project context, requirements, or guidelines that LLMs should consider when working with tasks in this list.",
       "Include links to related tasks, spaces, or external resources in the appended content.",
-      "Content is appended in markdown format with timestamp for tracking changes."
+      "Content is appended in markdown format with timestamp for tracking changes.",
     ].join("\n"),
     {
       list_id: z.string().min(1).describe("The list ID to update"),
-      append_description: z.string().min(1).describe("Markdown content to APPEND to existing list description (preserves existing content for safety)")
+      append_description: z
+        .string()
+        .min(1)
+        .describe(
+          "Markdown content to APPEND to existing list description (preserves existing content for safety)",
+        ),
     },
     {
       readOnlyHint: false,
@@ -142,37 +262,54 @@ export function registerListToolsWrite(server: McpServer) {
     async ({ list_id, append_description }) => {
       try {
         // Get current list info including description (try to get markdown content)
-        const listResponse = await fetch(`https://api.clickup.com/api/v2/list/${list_id}?include_markdown_description=true`, {
-          headers: { Authorization: CONFIG.apiKey },
-        });
+        const listResponse = await fetch(
+          `https://api.clickup.com/api/v2/list/${list_id}?include_markdown_description=true`,
+          {
+            headers: { Authorization: CONFIG.apiKey },
+          },
+        );
 
         if (!listResponse.ok) {
-          throw new Error(`Error fetching list: ${listResponse.status} ${listResponse.statusText}`);
+          throw new Error(
+            `Error fetching list: ${listResponse.status} ${listResponse.statusText}`,
+          );
         }
 
         const listData = await listResponse.json();
 
         // Handle append-only description update with markdown support
-        const currentDescription = listData.markdown_description || listData.markdown_content || listData.content || "";
-        const timestamp = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
+        const currentDescription =
+          listData.markdown_description ||
+          listData.markdown_content ||
+          listData.content ||
+          "";
+        const timestamp = new Date().toISOString().split("T")[0]; // YYYY-MM-DD format
         const separator = currentDescription.trim() ? "\n\n---\n" : "";
-        const finalDescription = currentDescription + separator + `**Edit (${timestamp}):** ${append_description}`;
+        const finalDescription =
+          currentDescription +
+          separator +
+          `**Edit (${timestamp}):** ${append_description}`;
 
         // Update the list description using markdown_content
-        const updateResponse = await fetch(`https://api.clickup.com/api/v2/list/${list_id}`, {
-          method: 'PUT',
-          headers: {
-            Authorization: CONFIG.apiKey,
-            'Content-Type': 'application/json'
+        const updateResponse = await fetch(
+          `https://api.clickup.com/api/v2/list/${list_id}`,
+          {
+            method: "PUT",
+            headers: {
+              Authorization: CONFIG.apiKey,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              markdown_content: finalDescription,
+            }),
           },
-          body: JSON.stringify({
-            markdown_content: finalDescription
-          })
-        });
+        );
 
         if (!updateResponse.ok) {
           const errorData = await updateResponse.json().catch(() => ({}));
-          throw new Error(`Error updating list: ${updateResponse.status} ${updateResponse.statusText} - ${JSON.stringify(errorData)}`);
+          throw new Error(
+            `Error updating list: ${updateResponse.status} ${updateResponse.statusText} - ${JSON.stringify(errorData)}`,
+          );
         }
 
         return {
@@ -183,9 +320,8 @@ export function registerListToolsWrite(server: McpServer) {
             },
           ],
         };
-
       } catch (error) {
-        console.error('Error updating list info:', error);
+        console.error("Error updating list info:", error);
         return {
           content: [
             {
@@ -195,6 +331,6 @@ export function registerListToolsWrite(server: McpServer) {
           ],
         };
       }
-    }
+    },
   );
 }


### PR DESCRIPTION
## Summary

  - Add new `getFolderInfo` MCP tool that retrieves folder details (name, lists, parent space, statuses, metadata) from a folder ID
  - Add cached `getFolderDetails` utility function following the existing promise-caching pattern
  - Register the tool in both `read` and `write` modes
  - Add test coverage

  ## Motivation

  Previously, the only way to discover folder contents was through `searchSpaces`, which returns the full space tree. There was no way to directly query a specific folder by ID (e.g. extracted from a ClickUp URL like
  `https://app.clickup.com/{team_id}/v/f/{folder_id}/{space_id}`).

  This enables use cases like asking the AI: *"What lists are in the 'AI team sprints' folder?"* — the AI can now resolve the folder, list its sprint lists, and then search for tasks within them.

  ## Test plan

  - [x] `npm run build` compiles without errors
  - [x] `npm run test` passes (32/32 tests, including new `getFolderInfo` test)
  - [x] Manual test via `npm run cli getFolderInfo folder_id="<folder_id>"` returns expected folder data
  - [x] Tested live through Claude Code MCP integration