### PR TITLE
Extend searchSpaces to support folder_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added comparison table in README showing differences between this MCP and the official ClickUp MCP
+- Extended `searchSpaces` with `folder_id` parameter to resolve a ClickUp folder by ID, returning its lists, statuses, and parent space
 
 ### Fixed
 - Fixed image MIME type detection by inspecting binary magic bytes instead of trusting HTTP headers or fallback values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended `searchSpaces` with `folder_id` parameter to resolve a ClickUp folder by ID, returning its lists, statuses, and parent space
 
 ### Fixed
+- `getFolderDetails()` now fetches lists via dedicated `/folder/{id}/list` endpoint instead of relying on the folder payload embedding them
 - Fixed image MIME type detection by inspecting binary magic bytes instead of trusting HTTP headers or fallback values
 
 ## [1.6.0] - 2025-11-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Custom Task ID support** - All tools accepting a `task_id` (`getTaskById`, `addComment`, `updateTask`, `searchTasks`) now accept custom task IDs (e.g. `SOI-4422`) in addition to internal IDs. Custom IDs are automatically resolved to internal IDs via the ClickUp API.
 - Added comparison table in README showing differences between this MCP and the official ClickUp MCP
 - Extended `searchSpaces` with `folder_id` parameter to resolve a ClickUp folder by ID, returning its lists, statuses, and parent space
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ClickUp MCP for AI Assistants
 
+> **Fork** of [@hauptsache.net/clickup-mcp](https://github.com/hauptsacheNet/clickup-mcp) with custom task ID support and additional features.
+
 Model Context Protocol (MCP) server enabling AI assistants to interact with ClickUp workspaces. Get complete task context with comments and images, search across projects, create and update tasks, collaborate through comments, and track time - all through natural language.
 
 ## This MCP vs Official ClickUp MCP
@@ -62,7 +64,7 @@ Turn natural language into powerful ClickUp actions:
 - *"Add a comment to the design task about the new wireframes"*
 
 **Document Management:**
-- *"Find documents about job posting in hauptsache.net space"*
+- *"Find documents about job posting in my space"*
 - *"Search for API documentation across all spaces"*
 - *"Read the API documentation in the development space"*
 - *"Create a new requirements document for the mobile app project"*
@@ -109,7 +111,7 @@ For all installation methods, you'll need:
 
 ### Option 1: MCPB Bundle (Recommended for Claude Desktop)
 
-Download the pre-built bundle from our [releases page](https://github.com/hauptsacheNet/clickup-mcp/releases). This method requires no Node.js installation.
+Download the pre-built bundle from our [releases page](https://github.com/sebastienheyd/clickup-mcp/releases). This method requires no Node.js installation.
 
 You'll get a configuration screen where you are prompted to enter your API key and team ID.
 
@@ -127,7 +129,7 @@ Add the following to your MCP configuration file:
     "clickup": {
       "command": "npx",
       "args": [
-        "@hauptsache.net/clickup-mcp@latest"
+        "@sebastienheyd/clickup-mcp@latest"
       ],
       "env": {
         "CLICKUP_API_KEY": "your_api_key",
@@ -155,7 +157,7 @@ claude mcp add --scope user clickup \
   --env CLICKUP_MCP_MODE=read-minimal \
   --env MAX_IMAGES=16 \
   --env MAX_RESPONSE_SIZE_MB=4 \
-  -- npx -y @hauptsache.net/clickup-mcp
+  -- npx -y @sebastienheyd/clickup-mcp
 ```
 
 > Claude Code can handle a lot of images, thus the recommended increased limits.
@@ -167,7 +169,7 @@ Add these lines to your `~/.codex/config.toml` file:
 ```toml
 [mcp_servers.clickup]
 command = "npx"
-args = ["-y", "@hauptsache.net/clickup-mcp@latest"]
+args = ["-y", "@sebastienheyd/clickup-mcp@latest"]
 env = { "CLICKUP_API_KEY" = "YOUR_KEY", "CLICKUP_TEAM_ID" = "YOUR_ID", "CLICKUP_MCP_MODE" = "read-minimal" }
 ```
 
@@ -209,7 +211,7 @@ Add the mode to your MCP configuration:
   "mcpServers": {
     "clickup": {
       "command": "npx",
-      "args": ["-y", "@hauptsache.net/clickup-mcp@latest"],
+      "args": ["-y", "@sebastienheyd/clickup-mcp@latest"],
       "env": {
         "CLICKUP_API_KEY": "your_api_key",
         "CLICKUP_TEAM_ID": "your_team_id",

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "searchSpaces",
-      "description": "Search spaces (projects) by name or ID with fuzzy matching. Automatically fetches complete tree structure with lists, folders, and documents for 5 or fewer matches."
+      "description": "Search spaces (projects) by name or ID with fuzzy matching. Automatically fetches complete tree structure with lists, folders, and documents for 5 or fewer matches. Can also resolve a specific folder by folder_id to get its lists, statuses, and parent space."
     },
     {
       "name": "getListInfo",

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
   "tools": [
     {
       "name": "getTaskById",
-      "description": "Get a ClickUp task with images and comments by ID. Always use this URL when referencing tasks in conversations or sharing with others."
+      "description": "Get a ClickUp task with images and comments by ID. Supports both internal IDs (e.g. 869c4za0g) and custom task IDs (e.g. SOI-4422). Always use this URL when referencing tasks in conversations or sharing with others."
     },
     {
       "name": "addComment",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "0.2",
-  "name": "@hauptsache.net/clickup-mcp",
+  "name": "@sebastienheyd/clickup-mcp",
   "display_name": "ClickUp",
   "icon": "icon-72x72.png",
   "version": "1.6.1",
@@ -10,9 +10,15 @@
     "email": "marco@hauptsache.net",
     "url": "https://github.com/Nemo64"
   },
-  "homepage": "https://www.hauptsache.net",
-  "documentation": "https://github.com/hauptsacheNet/clickup-mcp/blob/main/README.md",
-  "support": "https://github.com/hauptsacheNet/clickup-mcp/issues",
+  "contributors": [
+    {
+      "name": "Sébastien HEYD",
+      "url": "https://github.com/sebastienheyd"
+    }
+  ],
+  "homepage": "https://github.com/sebastienheyd/clickup-mcp",
+  "documentation": "https://github.com/sebastienheyd/clickup-mcp/blob/main/README.md",
+  "support": "https://github.com/sebastienheyd/clickup-mcp/issues",
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",
@@ -120,6 +126,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hauptsacheNet/clickup-mcp.git"
+    "url": "git+https://github.com/sebastienheyd/clickup-mcp.git"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hauptsache.net/clickup-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hauptsache.net/clickup-mcp",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@hauptsache.net/clickup-mcp",
+  "name": "@sebastienheyd/clickup-mcp",
   "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@hauptsache.net/clickup-mcp",
+      "name": "@sebastienheyd/clickup-mcp",
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hauptsache.net/clickup-mcp",
+  "name": "@sebastienheyd/clickup-mcp",
   "version": "1.6.1",
   "description": "Search, create, and retrieve tasks, add comments, and track time through natural language commands.",
   "main": "dist/index.js",
@@ -35,8 +35,8 @@
     "automation"
   ],
   "author": {
-    "name": "Marco Pfeiffer",
-    "email": "marco@hauptsache.net"
+    "name": "Sébastien HEYD",
+    "url": "https://github.com/sebastienheyd"
   },
   "license": "MIT",
   "dependencies": {
@@ -63,10 +63,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hauptsacheNet/clickup-mcp.git"
+    "url": "git+https://github.com/sebastienheyd/clickup-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/hauptsacheNet/clickup-mcp/issues"
+    "url": "https://github.com/sebastienheyd/clickup-mcp/issues"
   },
-  "homepage": "https://github.com/hauptsacheNet/clickup-mcp#readme"
+  "homepage": "https://github.com/sebastienheyd/clickup-mcp#readme"
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -12,6 +12,50 @@ export function isTaskId(str: string): boolean {
   return /^[a-z0-9]{6,9}$/i.test(str);
 }
 
+/**
+ * Checks if a string looks like a ClickUp custom task ID (e.g. "SOI-4422", "PQP-123")
+ */
+export function isCustomTaskId(str: string): boolean {
+  return /^[A-Z]{1,10}-\d+$/i.test(str);
+}
+
+/**
+ * Resolves a custom task ID to an internal task ID via the ClickUp API
+ */
+export async function resolveCustomTaskId(customId: string): Promise<string> {
+  const response = await fetch(
+    `https://api.clickup.com/api/v2/task/${customId}?custom_task_ids=true&team_id=${CONFIG.teamId}`,
+    { headers: { Authorization: CONFIG.apiKey } }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Task not found for custom ID "${customId}": ${response.status} ${response.statusText}`);
+  }
+
+  const task = await response.json();
+  if (!task || !task.id) {
+    throw new Error(`Task not found for custom ID "${customId}"`);
+  }
+
+  console.error(`Resolved custom task ID "${customId}" to internal ID "${task.id}"`);
+  return task.id;
+}
+
+/**
+ * Resolves a task ID (internal or custom) to an internal task ID.
+ * If the ID is already an internal ID, returns it as-is.
+ * If the ID is a custom ID (e.g. "SOI-4422"), resolves it via the API.
+ */
+export async function resolveTaskId(id: string): Promise<string> {
+  if (isTaskId(id)) {
+    return id;
+  }
+  if (isCustomTaskId(id)) {
+    return resolveCustomTaskId(id);
+  }
+  throw new Error(`Invalid task ID format: "${id}". Expected an internal ID (6-9 alphanumeric characters) or a custom ID (e.g. "SOI-4422").`);
+}
+
 // Cache for current user info to avoid repeated API calls and race conditions
 let cachedUserPromise: Promise<any> | null = null;
 

--- a/src/tests/searchSpaces.test.ts
+++ b/src/tests/searchSpaces.test.ts
@@ -72,6 +72,7 @@ test("searchSpaces with folder_id returns folder details", async (t) => {
   setGlobalDispatcher(mockAgent);
   const client = mockAgent.get("https://api.clickup.com");
 
+  // GET /folder/{id} returns folder metadata without lists
   client
     .intercept({ path: "/api/v2/folder/folder123", method: "GET" })
     .reply(200, {
@@ -79,6 +80,12 @@ test("searchSpaces with folder_id returns folder details", async (t) => {
       name: "My Folder",
       archived: false,
       space: { id: "s1", name: "Alpha" },
+    });
+
+  // GET /folder/{id}/list returns the folder's lists
+  client
+    .intercept({ path: "/api/v2/folder/folder123/list", method: "GET" })
+    .reply(200, {
       lists: [
         {
           id: "list1",

--- a/src/tests/searchSpaces.test.ts
+++ b/src/tests/searchSpaces.test.ts
@@ -59,3 +59,69 @@ test("searchSpaces fetches spaces and related content", async (t) => {
   await mockAgent.close();
   t.mock.timers.reset();
 });
+
+test("searchSpaces with folder_id returns folder details", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerSpaceTools } = await import("../tools/space-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/folder/folder123", method: "GET" })
+    .reply(200, {
+      id: "folder123",
+      name: "My Folder",
+      archived: false,
+      space: { id: "s1", name: "Alpha" },
+      lists: [
+        {
+          id: "list1",
+          name: "Todo List",
+          task_count: 5,
+          statuses: [
+            { status: "open" },
+            { status: "in progress" },
+            { status: "done" },
+          ],
+        },
+        {
+          id: "list2",
+          name: "Bug List",
+          task_count: 3,
+          statuses: [],
+        },
+      ],
+    });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerSpaceTools(serverStub);
+
+  const result = await tools.searchSpaces({ folder_id: "folder123" });
+  const text = result.content.map((b: any) => b.text || "").join("\n");
+  assert.ok(text.includes("FOLDER: My Folder"));
+  assert.ok(text.includes("folder_id: folder123"));
+  assert.ok(text.includes("Todo List"));
+  assert.ok(text.includes("Bug List"));
+  assert.ok(text.includes("Parent space: Alpha"));
+
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tools/search-tools.ts
+++ b/src/tools/search-tools.ts
@@ -1,7 +1,7 @@
 import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {z} from "zod";
 import {CONFIG} from "../shared/config";
-import {isTaskId, getTaskSearchIndex, performMultiTermSearch} from "../shared/utils";
+import {isTaskId, isCustomTaskId, getTaskSearchIndex, performMultiTermSearch} from "../shared/utils";
 import {generateTaskMetadata} from "./task-tools";
 
 const MAX_SEARCH_RESULTS = 50;
@@ -118,8 +118,9 @@ export function registerSearchTools(server: McpServer, userData: any) {
         uniqueResults.set(task.id, { item: task, score: 0.1 }); // Give search results a good score
       });
 
-      // Task ID Fallback Logic
+      // Task ID Fallback Logic (internal IDs and custom IDs)
       const potentialTaskIds = terms.filter(isTaskId);
+      const potentialCustomIds = terms.filter(id => isCustomTaskId(id) && !isTaskId(id));
       const foundTaskIdsByFuse = new Set(Array.from(uniqueResults.keys()).map(id => id.toLowerCase()));
 
       const taskIdsToFetchDirectly = potentialTaskIds.filter(id => {
@@ -127,6 +128,7 @@ export function registerSearchTools(server: McpServer, userData: any) {
         return !foundTaskIdsByFuse.has(lowerId);
       });
 
+      // Fetch internal task IDs not found in index
       if (taskIdsToFetchDirectly.length > 0) {
         console.error(`Attempting direct fetch for task IDs: ${taskIdsToFetchDirectly.join(', ')}`);
         const directFetchPromises = taskIdsToFetchDirectly.map(async (id) => {
@@ -152,6 +154,34 @@ export function registerSearchTools(server: McpServer, userData: any) {
           }
         });
         await Promise.all(directFetchPromises);
+      }
+
+      // Fetch custom task IDs via the custom_task_ids API parameter
+      if (potentialCustomIds.length > 0) {
+        console.error(`Attempting direct fetch for custom task IDs: ${potentialCustomIds.join(', ')}`);
+        const customFetchPromises = potentialCustomIds.map(async (customId) => {
+          try {
+            const response = await fetch(
+              `https://api.clickup.com/api/v2/task/${customId}?custom_task_ids=true&team_id=${CONFIG.teamId}`,
+              {headers: {Authorization: CONFIG.apiKey}}
+            );
+            if (response.ok) {
+              const task = await response.json();
+              if (task && typeof task.id === 'string') {
+                const existing = uniqueResults.get(task.id);
+                if (!existing || 0 < existing.score) {
+                  uniqueResults.set(task.id, {item: task, score: 0});
+                }
+              }
+              return task;
+            }
+            return null;
+          } catch (error) {
+            console.error(`Error directly fetching custom task ${customId}:`, error);
+            return null;
+          }
+        });
+        await Promise.all(customFetchPromises);
       }
 
       let resultTasks = Array.from(uniqueResults.values())

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { convertMarkdownToToolCallResult, convertClickUpTextItemsToToolCallResult } from "../clickup-text";
 import { ContentBlock, DatedContentEvent, ImageMetadataBlock } from "../shared/types";
 import { CONFIG } from "../shared/config";
-import { isTaskId, getSpaceDetails, getAllTeamMembers } from "../shared/utils";
+import { isTaskId, isCustomTaskId, resolveTaskId, getSpaceDetails, getAllTeamMembers } from "../shared/utils";
 import { downloadImages } from "../shared/image-processing";
 
 // Read-specific utility functions
@@ -19,24 +19,26 @@ export function registerTaskToolsRead(server: McpServer, userData: any) {
     {
       id: z
         .string()
-        .min(6)
-        .max(9)
-        .refine(val => isTaskId(val), {
-          message: "Task ID must be 6-9 alphanumeric characters only"
+        .min(1)
+        .refine(val => isTaskId(val) || isCustomTaskId(val), {
+          message: "Must be an internal task ID (6-9 alphanumeric characters) or a custom task ID (e.g. SOI-4422)"
         })
         .describe(
-          `The 6-9 character ID of the task to get without a prefix like "#", "CU-" or "https://app.clickup.com/t/"`
+          `The task ID: either an internal ID (6-9 alphanumeric characters like "869c4za0g") or a custom task ID (e.g. "SOI-4422"). Do not include prefixes like "#", "CU-" or URLs.`
         ),
     },
     {
       readOnlyHint: true
     },
     async ({ id }) => {
+      // Resolve custom task ID to internal ID if needed
+      const resolvedId = await resolveTaskId(id);
+
       // 1. Load base task content, comment events, and status change events in parallel
       const [taskDetailContentBlocks, commentEvents, statusChangeEvents] = await Promise.all([
-        loadTaskContent(id), // Returns Promise<ContentBlock[]>
-        loadTaskComments(id), // Returns Promise<DatedContentEvent[]>
-        loadTimeInStatusHistory(id), // Returns Promise<DatedContentEvent[]>
+        loadTaskContent(resolvedId), // Returns Promise<ContentBlock[]>
+        loadTaskComments(resolvedId), // Returns Promise<DatedContentEvent[]>
+        loadTimeInStatusHistory(resolvedId), // Returns Promise<DatedContentEvent[]>
       ]);
 
       // 2. Combine comment and status change events

--- a/src/tools/task-write-tools.ts
+++ b/src/tools/task-write-tools.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { CONFIG } from "../shared/config";
-import { getCurrentUser } from "../shared/utils";
+import { getCurrentUser, isTaskId, isCustomTaskId, resolveTaskId } from "../shared/utils";
 import { convertMarkdownToClickUpBlocks } from "../clickup-text";
 
 // Shared schemas for task parameters
@@ -35,7 +35,9 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
       return descriptionBase.join("\n");
     })(),
     {
-      task_id: z.string().min(6).max(9).describe("The 6-9 character task ID to comment on"),
+      task_id: z.string().min(1).refine(val => isTaskId(val) || isCustomTaskId(val), {
+        message: "Must be an internal task ID (6-9 alphanumeric characters) or a custom task ID (e.g. SOI-4422)"
+      }).describe("The task ID to comment on: internal ID (e.g. \"869c4za0g\") or custom ID (e.g. \"SOI-4422\")"),
       comment: z.string().min(1).describe("The comment text to add to the task"),
     },
     {
@@ -45,6 +47,9 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
     },
     async ({ task_id, comment }) => {
       try {
+        // Resolve custom task ID to internal ID if needed
+        const resolved_task_id = await resolveTaskId(task_id);
+
         // Convert markdown to ClickUp formatted blocks
         const commentBlocks = convertMarkdownToClickUpBlocks(comment);
 
@@ -53,7 +58,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
           notify_all: true
         };
 
-        const response = await fetch(`https://api.clickup.com/api/v2/task/${task_id}/comment`, {
+        const response = await fetch(`https://api.clickup.com/api/v2/task/${resolved_task_id}/comment`, {
           method: 'POST',
           headers: {
             Authorization: CONFIG.apiKey,
@@ -76,7 +81,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
               text: [
                 `Comment added successfully!`,
                 `comment_id: ${commentData.id || 'N/A'}`,
-                `task_id: ${task_id}`,
+                `task_id: ${resolved_task_id}`,
                 `comment: ${comment}`,
                 `date: ${timestampToIso(commentData.date || Date.now())}`,
                 `user: ${commentData.user?.username || 'Current user'}`,
@@ -122,7 +127,9 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
       return descriptionBase.join("\n");
     })(),
     {
-      task_id: z.string().min(6).max(9).describe("The 6-9 character task ID to update"),
+      task_id: z.string().min(1).refine(val => isTaskId(val) || isCustomTaskId(val), {
+        message: "Must be an internal task ID (6-9 alphanumeric characters) or a custom task ID (e.g. SOI-4422)"
+      }).describe("The task ID to update: internal ID (e.g. \"869c4za0g\") or custom ID (e.g. \"SOI-4422\")"),
       name: taskNameSchema.optional(),
       append_description: z.string().optional().describe("Optional markdown content to APPEND to existing task description (preserves existing content for safety)"),
       status: z.string().optional().describe("Optional new status name - use getListInfo to see valid options"),
@@ -145,10 +152,13 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
     },
     async ({ task_id, name, append_description, status, priority, due_date, start_date, time_estimate, tags, parent_task_id, assignees, blocking, waiting_on, linked_tasks }) => {
       try {
+        // Resolve custom task ID to internal ID if needed
+        const resolved_task_id = await resolveTaskId(task_id);
+
         const userData = await getCurrentUser();
 
         // Get task details including current markdown description
-        const taskResponse = await fetch(`https://api.clickup.com/api/v2/task/${task_id}?include_markdown_description=true`, {
+        const taskResponse = await fetch(`https://api.clickup.com/api/v2/task/${resolved_task_id}?include_markdown_description=true`, {
           headers: { Authorization: CONFIG.apiKey },
         });
 
@@ -162,7 +172,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
         let dependencyUpdateResults: string[] = [];
         if (blocking !== undefined || waiting_on !== undefined || linked_tasks !== undefined) {
           const dependencyResults = await updateTaskDependencies(
-            task_id,
+            resolved_task_id,
             taskData,
             { blocking, waiting_on, linked_tasks }
           );
@@ -181,7 +191,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
           for (const tagName of tagsToAdd) {
             try {
               const addTagResponse = await fetch(
-                `https://api.clickup.com/api/v2/task/${task_id}/tag/${encodeURIComponent(tagName)}`,
+                `https://api.clickup.com/api/v2/task/${resolved_task_id}/tag/${encodeURIComponent(tagName)}`,
                 {
                   method: 'POST',
                   headers: { Authorization: CONFIG.apiKey }
@@ -201,7 +211,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
           for (const tagName of tagsToRemove) {
             try {
               const removeTagResponse = await fetch(
-                `https://api.clickup.com/api/v2/task/${task_id}/tag/${encodeURIComponent(tagName)}`,
+                `https://api.clickup.com/api/v2/task/${resolved_task_id}/tag/${encodeURIComponent(tagName)}`,
                 {
                   method: 'DELETE',
                   headers: { Authorization: CONFIG.apiKey }
@@ -257,7 +267,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
         // Update the task (if there are non-tag updates)
         let updatedTask = taskData;
         if (Object.keys(updateBody).length > 0) {
-          const updateResponse = await fetch(`https://api.clickup.com/api/v2/task/${task_id}`, {
+          const updateResponse = await fetch(`https://api.clickup.com/api/v2/task/${resolved_task_id}`, {
             method: 'PUT',
             headers: {
               Authorization: CONFIG.apiKey,
@@ -276,7 +286,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
 
         // If only tags or dependencies were updated, fetch the task again to get the updated state
         if ((tags !== undefined || blocking !== undefined || waiting_on !== undefined || linked_tasks !== undefined) && Object.keys(updateBody).length === 0) {
-          const refreshResponse = await fetch(`https://api.clickup.com/api/v2/task/${task_id}`, {
+          const refreshResponse = await fetch(`https://api.clickup.com/api/v2/task/${resolved_task_id}`, {
             headers: { Authorization: CONFIG.apiKey },
           });
           if (refreshResponse.ok) {


### PR DESCRIPTION
## Summary

- Adds `folder_id` parameter to `searchSpaces` tool to resolve a ClickUp folder by its ID
- Adds `getFolderDetails()` utility with promise-based caching (same pattern as `getSpaceDetails`)
- Adds `formatFolderTree()` to format folder tree structure (lists, statuses, parent space)
- Includes test coverage for the folder_id branch

This is the alternative approach suggested by @Nemo64 in #17: instead of creating a separate `getFolderInfo` tool, this integrates folder resolution directly into `searchSpaces`. When `folder_id` is provided, the tool returns folder details (lists, statuses, parent space) and ignores the `terms` parameter.

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm run test` all 32 tests pass (including new folder_id test)
- [ ] `npm run cli searchSpaces folder_id="<a_folder_id>"` returns folder info