### PR TITLE
Fix searchTasks crash when getSpaceDetails returns 401

### DIFF
--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -282,9 +282,13 @@ export async function generateTaskMetadata(task: any, timeEntries?: any[], isDet
   let spaceIdForDisplay = task.space?.id || 'N/A';
 
   if (spaceName === 'Unknown Space' && task.space?.id) {
-    const spaceDetails = await getSpaceDetails(task.space.id);
-    if (spaceDetails && spaceDetails.name) {
-      spaceName = spaceDetails.name;
+    try {
+      const spaceDetails = await getSpaceDetails(task.space.id);
+      if (spaceDetails && spaceDetails.name) {
+        spaceName = spaceDetails.name;
+      }
+    } catch {
+      // Space details fetch can fail (e.g. 401) - gracefully keep "Unknown Space"
     }
   }
 


### PR DESCRIPTION
## Summary

- Wraps `getSpaceDetails` call in `generateTaskMetadata` with try-catch so a 401 (or any fetch error) doesn't crash `searchTasks`
- Space name gracefully falls back to `"Unknown Space"` instead of propagating the error

Fixes #20

## Context

Some API keys have permission to list tasks via `/api/v2/team/{teamId}/task` but not to access `/api/v2/space/{spaceId}`. Since the team endpoint returns tasks with only `space.id` (no `space.name`), `generateTaskMetadata` always triggers the `getSpaceDetails` fallback — which throws on 401 and crashes the entire search.

## Test plan

- [x] Verified locally with an API key that returns 401 on `/api/v2/space/{id}` — `searchTasks` now returns results with `space: Unknown Space (id)` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)