### PR TITLE
feat: add getTaskByCustomId tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,68 +8,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added `getTaskByCustomId` tool to look up tasks by their custom task ID (e.g. 'PREFIX-123') using the `custom_task_ids` API parameter
 - Added comparison table in README showing differences between this MCP and the official ClickUp MCP
 
 ### Fixed
+
 - Fixed image MIME type detection by inspecting binary magic bytes instead of trusting HTTP headers or fallback values
 
 ## [1.6.0] - 2025-11-25
 
 ### Added
+
 - **Full markdown support for comments** - `addComment` now converts markdown to ClickUp's rich text format
 - Comments now preserve formatting when reading back from ClickUp, including nested formatting
 
 ## [1.5.1] - 2025-10-02
 
 ### Changed
+
 - The space resource now has a `ClickUp Space` suffix in the title.
 - Add additional hints to all tools to potentially improve client handling.
 
 ### Added
+
 - Added Icon to the manifest.json file.
 
 ## [1.5.0] - 2025-10-01
 
 ### Breaking Changes
+
 - Replaced `writeDocument` tool with two focused tools for better clarity:
   - `updateDocumentPage`: Updates existing pages (requires doc_id and page_id)
   - `createDocumentOrPage`: Creates new documents or pages (uses space_id/list_id/doc_id)
 - This change makes parameter requirements clearer and eliminates the confusion between creating and updating operations
 
 ### Fixed
+
 - Fixed "my-todos" prompt failing with "Failed to get prompt" error in Claude Desktop by adding `prompts_generated: true` to manifest.json to declare runtime-generated prompts
 - Fixed critical bug in document page updates: now uses correct ClickUp API v3 endpoint (`/workspaces/{teamId}/docs/{docId}/pages/{pageId}`) instead of incorrect endpoint that was causing 404 errors
 - Fixed empty response handling in `updateDocumentPage` - now gracefully handles ClickUp API responses that don't return JSON body
 
 ### Removed
+
 - Removed `searchDocuments` tool as it only searched document names/spaces, not content, which confused LLMs that are trained on fulltext searches. Documents can still be discovered via `searchSpaces` (which includes documents in space tree) or by direct URL.
 
 ### Changed
+
 - Removed time entries from `searchTasks` results to improve reliability and prevent rate limit issues. Time entries are still available via `getTaskById` for individual tasks.
 - Updated `readDocument` to reference new tool names (`updateDocumentPage` and `createDocumentOrPage`) in its suggestions
 
 ## [1.4.3] - 2025-09-26
 
 ### Fixed
+
 - Add required `title` field to MCP space resources to comply with newer MCP specification
 
 ## [1.4.2] - 2025-09-23
 
 ### Added
+
 - Task dependency and relationship management in `updateTask` tool (thanks @itinance)
 
 ### Fixed
+
 - Strip inline base64 data URIs from `getTaskById` responses and surface them as proper image blocks instead of embedding them in text content
 
 ## [1.4.1] - 2025-08-31
 
 ### Fixed
+
 - Fixed tag management in `updateTask` - tags are now properly added/removed using dedicated API endpoints (thanks @itinance)
 - Fixed Claude Desktop dxt support. It had the word `cli` in the argument list which triggered the cli debug mode of this library.
 
 ## [1.4.0] - 2025-08-18
 
 ### Added
+
 - MCP Resources support for dynamic ClickUp space discovery
   - Spaces now appear in Claude Desktop's resource dropdown for easy selection
   - Dynamic resource templates provide real-time space listing without server restart
@@ -79,18 +94,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.2] - 2025-08-05
 
 ### Fixed
+
 - Fix `writeDocument` API response parsing when creating pages in existing documents
 - Add fallback handling for both nested (`data.page`) and flat response formats
 
 ## [1.3.1] - 2025-07-22
 
 ### Added
+
 - Add `readOnlyHint` annotations to all MCP tools to improve user experience
 - Add a prompt for "my-todos" in English and German, as a shortcut.
 
 ## [1.3.0] - 2025-07-11
 
 ### Added
+
 - Document management tools for ClickUp Docs
   - `readDocument` - Read documents with page structure and content
   - `searchDocuments` - Search documents by name and space with fuzzy matching
@@ -98,16 +116,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Server instructions with all ClickUp Spaces to help the LLM make better decisions.
 
 ### Fixed
+
 - Null attachment handling in task metadata
 - URL generation for lists and spaces
 
 ### Improved
+
 - Enhanced search relevance weighting for multi-term queries
 - Optimized search scoring with multiple term matches
 
 ## [1.2.0] - 2025-07-02
 
 ### Added
+
 - Claude DXT manifest.json file for enhanced integration
 - Intelligent image handling for ClickUp tasks
 - Parent task ID support in task creation and update operations
@@ -116,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Space search functionality replacing generic listing tools
 
 ### Changed
+
 - Task description and status update guidelines clarified
 - Server version now loaded dynamically from package.json
 - Improved caching for promises and enhanced time entries handling
@@ -123,22 +145,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified task-tools descriptions for assignees and update tracking
 
 ### Fixed
+
 - Enhanced promise caching to prevent race conditions
 
 ## [1.1.1] - 2025-06-17
 
 ### Added
+
 - ClickUp URL generation and markdown link formatting utilities
 - Enhanced time tools with team-wide filtering and hierarchical output
 - New formatting utilities for better data presentation
 
 ### Changed
+
 - Simplified private field handling and removed redundant URL guidance
 - Improved tool integration for enhanced navigation
 
 ## [1.1.0] - 2025-06-16
 
 ### Added
+
 - Safe append-only updates for task and list descriptions with markdown support
 - MCP mode support and tool segmentation for configurable functionality
 - Enhanced time and list tools with getListInfo functionality
@@ -147,6 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended valid task ID length to 6-9 characters
 
 ### Changed
+
 - Updated README with experimental notice and enhanced feature details
 - Enhanced tool descriptions with best practices and important usage notes
 - Enriched README with expanded usage examples and optimized AI workflows
@@ -155,24 +182,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified server setup and improved code modularity
 
 ### Fixed
+
 - Improved task creation and update functionalities for assignees
 
 ## [1.0.5] - 2025-06-03
 
 ### Added
+
 - Enhanced task metadata with priority, dates, time estimates, tags, watchers, URL, archived status, and custom fields
 
 ## [1.0.4] - 2025-05-26
 
 ### Added
+
 - Chronological status history and comment events to task content
 
 ### Fixed
+
 - Handle non-string text items in ClickUp text parser by stringifying unknown types
 
 ## [1.0.3] - 2025-05-22
 
 ### Added
+
 - Fuzzy search with Fuse.js and language-aware search guidance
 - Space details to task metadata and .env configuration support
 - Enhanced task search to support direct task ID lookups alongside text search
@@ -180,17 +212,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2025-05-09
 
 ### Added
+
 - Image limit functionality with MAX_IMAGES env var and newest-first sorting
 - Parent/child task metadata and improved documentation
 
 ## [1.0.1] - 2025-05-08
 
 ### Fixed
+
 - Executable configuration for npx usage
 
 ## [1.0.0] - 2025-05-08
 
 ### Added
+
 - Initial release of ClickUp MCP server
 - Task search and retrieval functionality
 - Markdown and text processing capabilities
@@ -199,8 +234,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic README with setup instructions
 
 ### Changed
+
 - Consolidated markdown and text processing into unified clickup-text module
 - Improved markdown image processing with dedicated loader function
 
 ### Fixed
+
 - Initial setup and configuration for npm publishing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Model Context Protocol (MCP) server enabling AI assistants to interact with Clic
 > See also: [Official ClickUp MCP Documentation](https://developer.clickup.com/docs/connect-an-ai-assistant-to-clickups-mcp-server)
 
 | Feature              | This MCP                                              | Official ClickUp MCP                        |
-|----------------------|-------------------------------------------------------|---------------------------------------------|
+| -------------------- | ----------------------------------------------------- | ------------------------------------------- |
 | **Setup**            | Local npm/npx install                                 | Remote MCP (no install)                     |
 | **Authentication**   | API key only                                          | OAuth only                                  |
 | **Task Context**     | Complete with comments, status history, inline images | Requires mutiple tool calls for full contxt |
@@ -21,11 +21,13 @@ Model Context Protocol (MCP) server enabling AI assistants to interact with Clic
 | **Support**          | Community (open source)                               | Official ClickUp                            |
 
 **Choose this MCP when:**
+
 - You need rich task context with inline images for AI coding tools
 - You need API key authentication for automation or CI/CD pipelines
 - You want the `read-minimal` mode optimized for development workflows
 
 **Choose Official MCP when:**
+
 - You need OAuth authentication for enterprise security compliance
 - You need Chat integration or Connected Search features
 - You want official support and no local installation
@@ -35,60 +37,71 @@ Model Context Protocol (MCP) server enabling AI assistants to interact with Clic
 Turn natural language into powerful ClickUp actions:
 
 **Agentic Coding & Development:**
-- *"Look at CU-abc123, can you find the relevant code?"*
-- *"Can you build the dashboard like described in https://app.clickup.com/t/12a23b45c?"*
-- *"Check task CU-xyz789 and fix the bugs mentioned in the comments"*
-- *"Implement the API endpoints described in the integration task"*
+
+- _"Look at CU-abc123, can you find the relevant code?"_
+- _"Can you build the dashboard like described in https://app.clickup.com/t/12a23b45c?"_
+- _"Check task CU-xyz789 and fix the bugs mentioned in the comments"_
+- _"Implement the API endpoints described in the integration task"_
+- _"Look at task DEV-42 and summarize what needs to be done"_ (custom task IDs)
 
 **Time Tracking & Productivity:**
-- *"Book 2 hours for the client meeting on the XYZ project"*
-- *"How much time did I spend on development tasks this week?"*
-- *"Log 30 minutes for code review on the authentication feature"*
+
+- _"Book 2 hours for the client meeting on the XYZ project"_
+- _"How much time did I spend on development tasks this week?"_
+- _"Log 30 minutes for code review on the authentication feature"_
 
 **Smart Search & Discovery:**
-- *"What task did I mention the CSV import in?"*
-- *"Find all tasks related to the payment gateway integration"*
-- *"Show me tasks where users reported login issues"*
+
+- _"What task did I mention the CSV import in?"_
+- _"Find all tasks related to the payment gateway integration"_
+- _"Show me tasks where users reported login issues"_
 
 **Daily Workflow Management:**
-- *"What do I need to do today?"*
-- *"Create a task for fixing the dashboard bug in the frontend list"*
-- *"Update the API documentation task to 'in review' status"*
-- *"What tasks are blocking the mobile app release?"*
+
+- _"What do I need to do today?"_
+- _"Create a task for fixing the dashboard bug in the frontend list"_
+- _"Update the API documentation task to 'in review' status"_
+- _"What tasks are blocking the mobile app release?"_
 
 **Rich Context & Collaboration:**
-- *"Show me all comments on the user authentication task"*
-- *"What's the latest update on the database migration?"*
-- *"Add a comment to the design task about the new wireframes"*
+
+- _"Show me all comments on the user authentication task"_
+- _"What's the latest update on the database migration?"_
+- _"Add a comment to the design task about the new wireframes"_
 
 **Document Management:**
-- *"Find documents about job posting in hauptsache.net space"*
-- *"Search for API documentation across all spaces"*
-- *"Read the API documentation in the development space"*
-- *"Create a new requirements document for the mobile app project"*
-- *"Update the meeting notes with today's decisions"*
-- *"What documents are in the product strategy space?"*
+
+- _"Find documents about job posting in hauptsache.net space"_
+- _"Search for API documentation across all spaces"_
+- _"Read the API documentation in the development space"_
+- _"Create a new requirements document for the mobile app project"_
+- _"Update the meeting notes with today's decisions"_
+- _"What documents are in the product strategy space?"_
 
 ## Key Features
 
 ### 🔍 **Intelligent Search**
+
 - Fuzzy matching across task names, descriptions, and comments
 - Multi-language search support for international teams
 - Filter by assignees, projects, status, and metadata
 
 ### 💬 **Complete Context**
+
 - Full comment histories and team discussions
-- Task descriptions with embedded images  
+- Task descriptions with embedded images
 - List descriptions and project guidelines
 - Document content with page navigation
 - Access to complete task history and decisions
 
 ### ⏱️ **Time Tracking**
+
 - Log time entries with descriptions
 - View historical time logs and entries
 - Query time entries by task or date range
 
 ### 📋 **Task & Document Management**
+
 - Create and update tasks with markdown descriptions
 - Create, read, and update documents and pages
 - Add comments and collaborate with team members
@@ -96,6 +109,7 @@ Turn natural language into powerful ClickUp actions:
 - Handle time estimates and custom field values
 
 ### 🔒 **Safety Features**
+
 - **Append-Only Descriptions**: Description fields are never overwritten - new content is safely appended with timestamps
 - **Normal Field Updates**: Status, priority, assignees, tags, and dates can be updated normally (easily revertible through ClickUp's history)
 
@@ -104,7 +118,8 @@ Turn natural language into powerful ClickUp actions:
 ### Prerequisites
 
 For all installation methods, you'll need:
-- Your `CLICKUP_API_KEY` (Profile Icon > Settings > Apps > API Token ~ usually starts with pk_)
+
+- Your `CLICKUP_API_KEY` (Profile Icon > Settings > Apps > API Token ~ usually starts with pk\_)
 - Your `CLICKUP_TEAM_ID` (The 7–10 digit number in the URL when you are in the settings)
 
 ### Option 1: MCPB Bundle (Recommended for Claude Desktop)
@@ -126,9 +141,7 @@ Add the following to your MCP configuration file:
   "mcpServers": {
     "clickup": {
       "command": "npx",
-      "args": [
-        "@hauptsache.net/clickup-mcp@latest"
-      ],
+      "args": ["@hauptsache.net/clickup-mcp@latest"],
       "env": {
         "CLICKUP_API_KEY": "your_api_key",
         "CLICKUP_TEAM_ID": "your_team_id"
@@ -141,6 +154,7 @@ Add the following to your MCP configuration file:
 Replace `your_api_key` and `your_team_id` with your actual ClickUp credentials.
 
 **Where to add this configuration:**
+
 - **Claude Desktop**: Settings > Developer > Edit Config
 - **Windsurf**: Add to your MCP configuration file
 - **Cursor**: Configure through the MCP settings panel
@@ -148,6 +162,7 @@ Replace `your_api_key` and `your_team_id` with your actual ClickUp credentials.
 ### Option 3: Coding Tools Integration
 
 **Claude Code (CLI):**
+
 ```bash
 claude mcp add --scope user clickup \
   --env CLICKUP_API_KEY=YOUR_KEY \
@@ -159,11 +174,12 @@ claude mcp add --scope user clickup \
 ```
 
 > Claude Code can handle a lot of images, thus the recommended increased limits.
- 
+
 > Note the `CLICKUP_MCP_MODE=read-minimal`. This is my usage recommendation, but feel free to use one of the other modes.
 
 **OpenAI Codex:**
 Add these lines to your `~/.codex/config.toml` file:
+
 ```toml
 [mcp_servers.clickup]
 command = "npx"
@@ -180,25 +196,26 @@ env = { "CLICKUP_API_KEY" = "YOUR_KEY", "CLICKUP_TEAM_ID" = "YOUR_ID", "CLICKUP_
 The ClickUp MCP supports three operational modes to balance functionality, security, and performance:
 
 - **🚀 `read-minimal`**: Perfect for AI coding assistants and context gathering
-- **📖 `read`**: Full read-only access for project exploration and workflow understanding  
+- **📖 `read`**: Full read-only access for project exploration and workflow understanding
 - **✏️ `write`** (Default): Complete functionality for task management and productivity workflows
 
 | Tool                   | read-minimal | read | write | Description                                                                             |
-|------------------------|:------------:|:----:|:-----:|-----------------------------------------------------------------------------------------|
-| `getTaskById`          |      ✅       |  ✅   |   ✅   | Get complete task details including comments, images, and metadata                      |
-| `addComment`           |      ❌       |  ❌   |   ✅   | Add comments to tasks for collaboration                                                 |
-| `updateTask`           |      ❌       |  ❌   |   ✅   | Update tasks (status, priority, assignees, etc.) with **SAFE APPEND-ONLY** descriptions |
-| `createTask`           |      ❌       |  ❌   |   ✅   | Create new tasks with full markdown support                                             |
-| `searchTasks`          |      ✅       |  ✅   |   ✅   | Find tasks by content, keywords, assignees, or project context                          |
-| `searchSpaces`         |      ❌       |  ✅   |   ✅   | Browse workspace structure, project organization, and documents                         |
-| `getListInfo`          |      ❌       |  ✅   |   ✅   | Get list details and available statuses for task creation                               |
-| `updateListInfo`       |      ❌       |  ❌   |   ✅   | **SAFE APPEND-ONLY** updates to list descriptions (preserves existing content)          |
-| `getTimeEntries`       |      ❌       |  ✅   |   ✅   | View time entries and analyze time spent across projects                                |
-| `createTimeEntry`      |      ❌       |  ❌   |   ✅   | Log time entries for task tracking                                                      |
-| `readDocument`         |      ❌       |  ✅   |   ✅   | Get document details, page structure, and content with navigation                       |
-| `searchDocuments`      |      ❌       |  ✅   |   ✅   | Search documents by name and space with fuzzy matching and space filtering              |
-| `updateDocumentPage`   |      ❌       |  ❌   |   ✅   | Update existing page content or name with replace/append modes                          |
-| `createDocumentOrPage` |      ❌       |  ❌   |   ✅   | Create new documents with first page, or add pages/sub-pages to existing documents      |
+| ---------------------- | :----------: | :--: | :---: | --------------------------------------------------------------------------------------- |
+| `getTaskById`          |      ✅      |  ✅  |  ✅   | Get complete task details including comments, images, and metadata                      |
+| `getTaskByCustomId`    |      ✅      |  ✅  |  ✅   | Get a task by its custom task ID (e.g. 'PREFIX-123') instead of the internal ID         |
+| `addComment`           |      ❌      |  ❌  |  ✅   | Add comments to tasks for collaboration                                                 |
+| `updateTask`           |      ❌      |  ❌  |  ✅   | Update tasks (status, priority, assignees, etc.) with **SAFE APPEND-ONLY** descriptions |
+| `createTask`           |      ❌      |  ❌  |  ✅   | Create new tasks with full markdown support                                             |
+| `searchTasks`          |      ✅      |  ✅  |  ✅   | Find tasks by content, keywords, assignees, or project context                          |
+| `searchSpaces`         |      ❌      |  ✅  |  ✅   | Browse workspace structure, project organization, and documents                         |
+| `getListInfo`          |      ❌      |  ✅  |  ✅   | Get list details and available statuses for task creation                               |
+| `updateListInfo`       |      ❌      |  ❌  |  ✅   | **SAFE APPEND-ONLY** updates to list descriptions (preserves existing content)          |
+| `getTimeEntries`       |      ❌      |  ✅  |  ✅   | View time entries and analyze time spent across projects                                |
+| `createTimeEntry`      |      ❌      |  ❌  |  ✅   | Log time entries for task tracking                                                      |
+| `readDocument`         |      ❌      |  ✅  |  ✅   | Get document details, page structure, and content with navigation                       |
+| `searchDocuments`      |      ❌      |  ✅  |  ✅   | Search documents by name and space with fuzzy matching and space filtering              |
+| `updateDocumentPage`   |      ❌      |  ❌  |  ✅   | Update existing page content or name with replace/append modes                          |
+| `createDocumentOrPage` |      ❌      |  ❌  |  ✅   | Create new documents with first page, or add pages/sub-pages to existing documents      |
 
 ### Setting the Mode
 
@@ -235,6 +252,7 @@ This MCP server can be configured using environment variables:
 ### Language-Aware Search Guidance
 
 The `searchTask` tool's description will dynamically adjust based on the detected primary language:
+
 - If `CLICKUP_PRIMARY_LANGUAGE` or `LANG` suggests a known primary language (e.g., German), the tool's description will specifically recommend providing search terms in both English and that detected language (e.g., German) for optimal results.
 - If no primary language is detected, a more general recommendation for multilingual workspaces will be provided.
 
@@ -247,6 +265,7 @@ Task descriptions and list documentation support full markdown formatting:
 ### Examples
 
 **Task Creation with Markdown:**
+
 ```
 Create a task called "API Integration" with description:
 # API Integration Requirements
@@ -273,11 +292,14 @@ See related task: https://app.clickup.com/t/abc123
 
 **Append-Only Updates (Safe):**
 When updating task descriptions, content is safely appended:
+
 ```markdown
 [Existing task description content]
 
 ---
+
 **Edit (2024-01-15):** Added new acceptance criteria based on client feedback:
+
 - Must support mobile responsive design
 - Performance requirement: < 2s load time
 ```
@@ -287,11 +309,13 @@ This ensures no existing content is ever lost while maintaining a clear audit tr
 ## Performance & Limitations
 
 **Optimized for AI Workflows:**
+
 - **Smart Image Processing**: Intelligent size budgeting prioritizes the most recent images while respecting both count (`MAX_IMAGES`, default: 4) and total response size limits (`MAX_RESPONSE_SIZE_MB`, default: 1MB)
 - **Search Scope**: Searches within the most recent 1000-3000 tasks to prevent running into rate limits (exact number varies by endpoint)
 - **Search Results**: Returns up to 50 most relevant matches to prevent flooding the agent with too many results
 
 **Current Scope:**
+
 - Focused on task-level operations rather than bulk workspace management
 - Optimized for conversational AI workflows rather than data migration
 - Designed for productivity enhancement, not administrative operations

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,10 @@
       "description": "Get a ClickUp task with images and comments by ID. Always use this URL when referencing tasks in conversations or sharing with others."
     },
     {
+      "name": "getTaskByCustomId",
+      "description": "Get a ClickUp task by its custom task ID (e.g. 'PREFIX-123'). Use this when you have a human-readable custom ID instead of the internal task ID."
+    },
+    {
       "name": "addComment",
       "description": "Add a comment to a specific task with linking best practices and progress updates."
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hauptsache.net/clickup-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hauptsache.net/clickup-mcp",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "start": "node dist/index.js",
     "dev": "npx tsc -w & nodemon dist/index.js",
     "cli": "npx ts-node src/cli.ts",

--- a/src/tests/getTaskByCustomId.test.ts
+++ b/src/tests/getTaskByCustomId.test.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MockAgent, setGlobalDispatcher } from "undici";
+
+test("getTaskByCustomId makes correct API calls with custom_task_ids param", async (t) => {
+  t.mock.timers.enable();
+  process.env.CLICKUP_API_KEY = "test-key";
+  process.env.CLICKUP_TEAM_ID = "team1";
+
+  const { registerTaskToolsRead } = await import("../tools/task-tools");
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const client = mockAgent.get("https://api.clickup.com");
+
+  client
+    .intercept({ path: "/api/v2/team", method: "GET" })
+    .reply(200, { teams: [{ id: "team1", members: [] }] });
+
+  // The task endpoint should be called with custom_task_ids=true&team_id=team1
+  client
+    .intercept({
+      path: (path: string) => {
+        return (
+          path.startsWith("/api/v2/task/DEV-42") &&
+          path.includes("custom_task_ids=true") &&
+          path.includes("team_id=team1")
+        );
+      },
+      method: "GET",
+    })
+    .reply(200, {
+      id: "abc123", // real task ID returned by API
+      name: "Test Task",
+      markdown_description: "",
+      attachments: [],
+      creator: { username: "creator", id: "1" },
+      assignees: [],
+      list: { id: "list1", name: "List" },
+      space: { id: "space1", name: "Space" },
+      status: { status: "open", type: "open" },
+      url: "https://app.clickup.com/t/abc123",
+      date_created: "0",
+      date_updated: "0",
+    });
+
+  // Subsequent calls should use the real task ID (abc123)
+  client
+    .intercept({ path: /\/api\/v2\/task\/abc123\/comment.*/, method: "GET" })
+    .reply(200, { comments: [] });
+
+  client
+    .intercept({ path: "/api/v2/task/abc123/time_in_status", method: "GET" })
+    .reply(200, { status_history: [], current_status: null });
+
+  client
+    .intercept({
+      path: /\/api\/v2\/team\/team1\/time_entries.*/,
+      method: "GET",
+    })
+    .reply(200, { data: [] });
+
+  const tools: Record<string, any> = {};
+  const serverStub = {
+    tool: (
+      name: string,
+      _desc: string,
+      _schema: any,
+      _opts: any,
+      handler: any,
+    ) => {
+      tools[name] = handler;
+    },
+  } as any;
+
+  registerTaskToolsRead(serverStub, { user: { username: "me", id: "u1" } });
+
+  const result = await tools.getTaskByCustomId({ customId: "DEV-42" });
+  assert.ok(
+    result.content.some(
+      (block: any) =>
+        typeof block.text === "string" &&
+        block.text.includes("task_id: abc123"),
+    ),
+  );
+
+  (mockAgent as any).assertNoPendingInterceptors();
+  await mockAgent.close();
+  t.mock.timers.reset();
+});

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -1,7 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { convertMarkdownToToolCallResult, convertClickUpTextItemsToToolCallResult } from "../clickup-text";
-import { ContentBlock, DatedContentEvent, ImageMetadataBlock } from "../shared/types";
+import {
+  convertMarkdownToToolCallResult,
+  convertClickUpTextItemsToToolCallResult,
+} from "../clickup-text";
+import {
+  ContentBlock,
+  DatedContentEvent,
+  ImageMetadataBlock,
+} from "../shared/types";
 import { CONFIG } from "../shared/config";
 import { isTaskId, getSpaceDetails, getAllTeamMembers } from "../shared/utils";
 import { downloadImages } from "../shared/image-processing";
@@ -14,33 +21,38 @@ export function registerTaskToolsRead(server: McpServer, userData: any) {
     [
       "Get a ClickUp task with images and comments by ID.",
       "Always use this URL when referencing tasks in conversations or sharing with others.",
-      "The response provides complete context including task details, comments, and status history."
+      "The response provides complete context including task details, comments, and status history.",
     ].join("\n"),
     {
       id: z
         .string()
         .min(6)
         .max(9)
-        .refine(val => isTaskId(val), {
-          message: "Task ID must be 6-9 alphanumeric characters only"
+        .refine((val) => isTaskId(val), {
+          message: "Task ID must be 6-9 alphanumeric characters only",
         })
         .describe(
-          `The 6-9 character ID of the task to get without a prefix like "#", "CU-" or "https://app.clickup.com/t/"`
+          `The 6-9 character ID of the task to get without a prefix like "#", "CU-" or "https://app.clickup.com/t/"`,
         ),
     },
     {
-      readOnlyHint: true
+      readOnlyHint: true,
     },
     async ({ id }) => {
       // 1. Load base task content, comment events, and status change events in parallel
-      const [taskDetailContentBlocks, commentEvents, statusChangeEvents] = await Promise.all([
-        loadTaskContent(id), // Returns Promise<ContentBlock[]>
-        loadTaskComments(id), // Returns Promise<DatedContentEvent[]>
-        loadTimeInStatusHistory(id), // Returns Promise<DatedContentEvent[]>
-      ]);
+      const [taskDetailResult, commentEvents, statusChangeEvents] =
+        await Promise.all([
+          loadTaskContent(id), // Returns Promise<{ contentBlocks, realTaskId }>
+          loadTaskComments(id), // Returns Promise<DatedContentEvent[]>
+          loadTimeInStatusHistory(id), // Returns Promise<DatedContentEvent[]>
+        ]);
+      const taskDetailContentBlocks = taskDetailResult.contentBlocks;
 
       // 2. Combine comment and status change events
-      const allDatedEvents: DatedContentEvent[] = [...commentEvents, ...statusChangeEvents];
+      const allDatedEvents: DatedContentEvent[] = [
+        ...commentEvents,
+        ...statusChangeEvents,
+      ];
 
       // 3. Sort all dated events chronologically
       allDatedEvents.sort((a, b) => {
@@ -56,17 +68,86 @@ export function registerTaskToolsRead(server: McpServer, userData: any) {
       }
 
       // 5. Combine task details with processed event blocks
-      const allContentBlocks: (ContentBlock | ImageMetadataBlock)[] = [...taskDetailContentBlocks, ...processedEventBlocks];
+      const allContentBlocks: (ContentBlock | ImageMetadataBlock)[] = [
+        ...taskDetailContentBlocks,
+        ...processedEventBlocks,
+      ];
 
       // 6. Download images with smart size limiting
-      const limitedContent: ContentBlock[] = await downloadImages(allContentBlocks);
+      const limitedContent: ContentBlock[] =
+        await downloadImages(allContentBlocks);
 
       return {
         content: limitedContent,
       };
-    }
+    },
   );
 
+  server.tool(
+    "getTaskByCustomId",
+    [
+      "Get a ClickUp task by its custom task ID (e.g. 'PREFIX-123').",
+      "Use this when you have a human-readable custom ID instead of the internal task ID.",
+      "The response provides complete context including task details, comments, and status history.",
+    ].join("\n"),
+    {
+      customId: z
+        .string()
+        .min(1)
+        .describe(
+          `The custom task ID (e.g. 'PREFIX-123') as configured in the ClickUp space.`,
+        ),
+    },
+    {
+      readOnlyHint: true,
+    },
+    async ({ customId }) => {
+      // 1. Load task content with custom_task_ids flag to resolve the real task ID
+      const taskDetailResult = await loadTaskContent(customId, {
+        customTaskIds: true,
+      });
+      const realTaskId = taskDetailResult.realTaskId;
+
+      // 2. Load comment events and status change events using the real task ID
+      const [commentEvents, statusChangeEvents] = await Promise.all([
+        loadTaskComments(realTaskId),
+        loadTimeInStatusHistory(realTaskId),
+      ]);
+
+      // 3. Combine comment and status change events
+      const allDatedEvents: DatedContentEvent[] = [
+        ...commentEvents,
+        ...statusChangeEvents,
+      ];
+
+      // 4. Sort all dated events chronologically
+      allDatedEvents.sort((a, b) => {
+        const dateA = a.date ? parseInt(a.date) : 0;
+        const dateB = b.date ? parseInt(b.date) : 0;
+        return dateA - dateB;
+      });
+
+      // 5. Flatten sorted events into a single ContentBlock stream
+      let processedEventBlocks: (ContentBlock | ImageMetadataBlock)[] = [];
+      for (const event of allDatedEvents) {
+        processedEventBlocks.push(...event.contentBlocks);
+      }
+
+      // 6. Combine task details with processed event blocks
+      const allContentBlocks: (ContentBlock | ImageMetadataBlock)[] = [
+        ...taskDetailResult.contentBlocks,
+        ...processedEventBlocks,
+      ];
+
+      // 7. Download images with smart size limiting
+      const limitedContent: ContentBlock[] =
+        await downloadImages(allContentBlocks);
+
+      return {
+        content: limitedContent,
+      };
+    },
+  );
 }
 
 /**
@@ -78,35 +159,54 @@ async function fetchTaskTimeEntries(taskId: string): Promise<any[]> {
     const teamMembers = await getAllTeamMembers();
     const params = new URLSearchParams({
       task_id: taskId,
-      include_location_names: 'true',
-      start_date: '0', // overwrite the default 30 days
+      include_location_names: "true",
+      start_date: "0", // overwrite the default 30 days
     });
 
     if (teamMembers.length > 0) {
-      params.append('assignee', teamMembers.join(','));
+      params.append("assignee", teamMembers.join(","));
     }
 
-    const response = await fetch(`https://api.clickup.com/api/v2/team/${CONFIG.teamId}/time_entries?${params}`, {
-      headers: { Authorization: CONFIG.apiKey },
-    });
+    const response = await fetch(
+      `https://api.clickup.com/api/v2/team/${CONFIG.teamId}/time_entries?${params}`,
+      {
+        headers: { Authorization: CONFIG.apiKey },
+      },
+    );
 
     if (!response.ok) {
-      console.error(`Error fetching time entries for task ${taskId}: ${response.status} ${response.statusText}`);
+      console.error(
+        `Error fetching time entries for task ${taskId}: ${response.status} ${response.statusText}`,
+      );
       return [];
     }
 
     const data = await response.json();
     return data.data || [];
   } catch (error) {
-    console.error('Error fetching task time entries:', error);
+    console.error("Error fetching task time entries:", error);
     return [];
   }
 }
 
-async function loadTaskContent(taskId: string): Promise<(ContentBlock | ImageMetadataBlock)[]> {
+async function loadTaskContent(
+  taskId: string,
+  options?: { customTaskIds?: boolean },
+): Promise<{
+  contentBlocks: (ContentBlock | ImageMetadataBlock)[];
+  realTaskId: string;
+}> {
+  const params = new URLSearchParams({
+    include_markdown_description: "true",
+    include_subtasks: "true",
+  });
+  if (options?.customTaskIds) {
+    params.set("custom_task_ids", "true");
+    params.set("team_id", CONFIG.teamId);
+  }
   const response = await fetch(
-    `https://api.clickup.com/api/v2/task/${taskId}?include_markdown_description=true&include_subtasks=true`,
-    { headers: { Authorization: CONFIG.apiKey } }
+    `https://api.clickup.com/api/v2/task/${taskId}?${params}`,
+    { headers: { Authorization: CONFIG.apiKey } },
   );
   const task = await response.json();
 
@@ -119,20 +219,22 @@ async function loadTaskContent(taskId: string): Promise<(ContentBlock | ImageMet
     // process markdown and download images
     convertMarkdownToToolCallResult(
       task.markdown_description || "",
-      task.attachments || []
+      task.attachments || [],
     ),
   ]);
 
-  return [taskMetadata, ...content];
+  return { contentBlocks: [taskMetadata, ...content], realTaskId: task.id };
 }
 
 async function loadTaskComments(id: string): Promise<DatedContentEvent[]> {
   const response = await fetch(
     `https://api.clickup.com/api/v2/task/${id}/comment?start_date=0`, // Ensure all comments are fetched
-    { headers: { Authorization: CONFIG.apiKey } }
+    { headers: { Authorization: CONFIG.apiKey } },
   );
   if (!response.ok) {
-    console.error(`Error fetching comments for task ${id}: ${response.status} ${response.statusText}`);
+    console.error(
+      `Error fetching comments for task ${id}: ${response.status} ${response.statusText}`,
+    );
     return [];
   }
   const commentsData = await response.json();
@@ -147,37 +249,52 @@ async function loadTaskComments(id: string): Promise<DatedContentEvent[]> {
         text: `Comment by ${comment.user.username} on ${timestampToIso(comment.date)}:`,
       };
 
-      const commentBodyBlocks: (ContentBlock | ImageMetadataBlock)[] = await convertClickUpTextItemsToToolCallResult(comment.comment);
+      const commentBodyBlocks: (ContentBlock | ImageMetadataBlock)[] =
+        await convertClickUpTextItemsToToolCallResult(comment.comment);
 
       return {
         date: comment.date, // String timestamp from ClickUp for sorting
         contentBlocks: [headerBlock, ...commentBodyBlocks],
       };
-    })
+    }),
   );
   return commentEvents;
 }
 
-async function loadTimeInStatusHistory(taskId: string): Promise<DatedContentEvent[]> {
+async function loadTimeInStatusHistory(
+  taskId: string,
+): Promise<DatedContentEvent[]> {
   const url = `https://api.clickup.com/api/v2/task/${taskId}/time_in_status`;
   try {
-    const response = await fetch(url, { headers: { Authorization: CONFIG.apiKey } });
+    const response = await fetch(url, {
+      headers: { Authorization: CONFIG.apiKey },
+    });
     if (!response.ok) {
-      console.error(`Error fetching time in status for task ${taskId}: ${response.status} ${response.statusText}`);
+      console.error(
+        `Error fetching time in status for task ${taskId}: ${response.status} ${response.statusText}`,
+      );
       return [];
     }
     // Using 'any' for less strict typing as per user preference, but keeping structure for clarity
-    const data: any = await response.json(); 
+    const data: any = await response.json();
     const events: DatedContentEvent[] = [];
 
     const processStatusEntry = (entry: any): DatedContentEvent | null => {
-      if (!entry || !entry.total_time || !entry.total_time.since || !entry.status) return null;
+      if (
+        !entry ||
+        !entry.total_time ||
+        !entry.total_time.since ||
+        !entry.status
+      )
+        return null;
       return {
         date: entry.total_time.since,
-        contentBlocks: [{
-          type: "text",
-          text: `Status set to '${entry.status}' on ${timestampToIso(entry.total_time.since)}`,
-        }],
+        contentBlocks: [
+          {
+            type: "text",
+            text: `Status set to '${entry.status}' on ${timestampToIso(entry.total_time.since)}`,
+          },
+        ],
       };
     };
 
@@ -196,19 +313,26 @@ async function loadTimeInStatusHistory(taskId: string): Promise<DatedContentEven
     }
 
     // Deduplicate events based on date and status name to avoid adding current_status if it's identical to the last history entry
-    const uniqueEvents = Array.from(new Map(events.map(event => {
-      const firstBlock = event.contentBlocks[0];
-      const textKey = firstBlock && 'text' in firstBlock ? firstBlock.text : 'unknown';
-      return [`${event.date}-${textKey}`, event];
-    })).values());
+    const uniqueEvents = Array.from(
+      new Map(
+        events.map((event) => {
+          const firstBlock = event.contentBlocks[0];
+          const textKey =
+            firstBlock && "text" in firstBlock ? firstBlock.text : "unknown";
+          return [`${event.date}-${textKey}`, event];
+        }),
+      ).values(),
+    );
 
     return uniqueEvents;
   } catch (error) {
-    console.error(`Exception fetching time in status for task ${taskId}:`, error);
+    console.error(
+      `Exception fetching time in status for task ${taskId}:`,
+      error,
+    );
     return [];
   }
 }
-
 
 /**
  * Formats timestamp to ISO string with local timezone (not UTC)
@@ -217,17 +341,21 @@ function timestampToIso(timestamp: number | string): string {
   const date = new Date(+timestamp);
 
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
 
   // Calculate timezone offset
   const offset = date.getTimezoneOffset();
   const offsetHours = Math.floor(Math.abs(offset) / 60);
   const offsetMinutes = Math.abs(offset) % 60;
-  const sign = offset <= 0 ? '+' : '-';
-  const timezoneOffset = sign + String(offsetHours).padStart(2, '0') + ':' + String(offsetMinutes).padStart(2, '0');
+  const sign = offset <= 0 ? "+" : "-";
+  const timezoneOffset =
+    sign +
+    String(offsetHours).padStart(2, "0") +
+    ":" +
+    String(offsetMinutes).padStart(2, "0");
 
   return `${year}-${month}-${day}T${hours}:${minutes}${timezoneOffset}`;
 }
@@ -235,13 +363,18 @@ function timestampToIso(timestamp: number | string): string {
 /**
  * Helper function to filter and format time entries for a specific task
  */
-function filterTaskTimeEntries(taskId: string, timeEntries: any[]): string | null {
+function filterTaskTimeEntries(
+  taskId: string,
+  timeEntries: any[],
+): string | null {
   if (!timeEntries || timeEntries.length === 0) {
     return null;
   }
 
   // Filter entries for this specific task
-  const taskEntries = timeEntries.filter((entry: any) => entry.task?.id === taskId);
+  const taskEntries = timeEntries.filter(
+    (entry: any) => entry.task?.id === taskId,
+  );
 
   if (taskEntries.length === 0) {
     return null;
@@ -251,7 +384,7 @@ function filterTaskTimeEntries(taskId: string, timeEntries: any[]): string | nul
   const timeByUser = new Map<string, number>();
 
   taskEntries.forEach((entry: any) => {
-    const username = entry.user?.username || 'Unknown User';
+    const username = entry.user?.username || "Unknown User";
     const currentTime = timeByUser.get(username) || 0;
     const entryDurationMs = parseInt(entry.duration) || 0;
     timeByUser.set(username, currentTime + entryDurationMs);
@@ -264,24 +397,29 @@ function filterTaskTimeEntries(taskId: string, timeEntries: any[]): string | nul
     const hours = totalMs / (1000 * 60 * 60);
     const displayHours = Math.floor(hours);
     const displayMinutes = Math.round((hours - displayHours) * 60);
-    const timeDisplay = displayHours > 0 ? 
-      `${displayHours}h ${displayMinutes}m` : 
-      `${displayMinutes}m`;
+    const timeDisplay =
+      displayHours > 0
+        ? `${displayHours}h ${displayMinutes}m`
+        : `${displayMinutes}m`;
 
     userTimeEntries.push(`${username}: ${timeDisplay}`);
   }
 
-  return userTimeEntries.length > 0 ? userTimeEntries.join(', ') : null;
+  return userTimeEntries.length > 0 ? userTimeEntries.join(", ") : null;
 }
 
 /**
  * Helper function to generate consistent task metadata
  */
-export async function generateTaskMetadata(task: any, timeEntries?: any[], isDetailView: boolean = false): Promise<ContentBlock> {
-  let spaceName = task.space?.name || 'Unknown Space';
-  let spaceIdForDisplay = task.space?.id || 'N/A';
+export async function generateTaskMetadata(
+  task: any,
+  timeEntries?: any[],
+  isDetailView: boolean = false,
+): Promise<ContentBlock> {
+  let spaceName = task.space?.name || "Unknown Space";
+  let spaceIdForDisplay = task.space?.id || "N/A";
 
-  if (spaceName === 'Unknown Space' && task.space?.id) {
+  if (spaceName === "Unknown Space" && task.space?.id) {
     const spaceDetails = await getSpaceDetails(task.space.id);
     if (spaceDetails && spaceDetails.name) {
       spaceName = spaceDetails.name;
@@ -296,14 +434,14 @@ export async function generateTaskMetadata(task: any, timeEntries?: any[], isDet
     `date_created: ${timestampToIso(task.date_created)}`,
     `date_updated: ${timestampToIso(task.date_updated)}`,
     `creator: ${task.creator.username} (${task.creator.id})`,
-    `assignee: ${task.assignees.map((a: any) => `${a.username} (${a.id})`).join(', ')}`,
+    `assignee: ${task.assignees.map((a: any) => `${a.username} (${a.id})`).join(", ")}`,
     `list: ${task.list.name} (${task.list.id})`,
     `space: ${spaceName} (${spaceIdForDisplay})`,
   ];
 
   // Add priority if it exists
   if (task.priority !== undefined && task.priority !== null) {
-    const priorityName = task.priority.priority || 'none';
+    const priorityName = task.priority.priority || "none";
     metadataLines.push(`priority: ${priorityName}`);
   }
 
@@ -335,12 +473,14 @@ export async function generateTaskMetadata(task: any, timeEntries?: any[], isDet
 
   // Add tags if they exist
   if (task.tags && task.tags.length > 0) {
-    metadataLines.push(`tags: ${task.tags.map((t: any) => t.name).join(', ')}`);
+    metadataLines.push(`tags: ${task.tags.map((t: any) => t.name).join(", ")}`);
   }
 
   // Add watchers if they exist
   if (task.watchers && task.watchers.length > 0) {
-    metadataLines.push(`watchers: ${task.watchers.map((w: any) => w.username).join(', ')}`);
+    metadataLines.push(
+      `watchers: ${task.watchers.map((w: any) => w.username).join(", ")}`,
+    );
   }
 
   // Add parent task information if it exists
@@ -350,9 +490,10 @@ export async function generateTaskMetadata(task: any, timeEntries?: any[], isDet
 
   // Add child task information if it exists
   if (task.subtasks && task.subtasks.length > 0) {
-    metadataLines.push(`child_task_ids: ${task.subtasks.map((st: any) => st.id).join(', ')}`);
+    metadataLines.push(
+      `child_task_ids: ${task.subtasks.map((st: any) => st.id).join(", ")}`,
+    );
   }
-
 
   // Add archived status if true
   if (task.archived) {
@@ -362,21 +503,30 @@ export async function generateTaskMetadata(task: any, timeEntries?: any[], isDet
   // Add custom fields if they exist
   if (task.custom_fields && task.custom_fields.length > 0) {
     task.custom_fields.forEach((field: any) => {
-      if (field.value !== undefined && field.value !== null && field.value !== '') {
-        const fieldName = field.name.toLowerCase().replace(/\s+/g, '_');
+      if (
+        field.value !== undefined &&
+        field.value !== null &&
+        field.value !== ""
+      ) {
+        const fieldName = field.name.toLowerCase().replace(/\s+/g, "_");
         let fieldValue = field.value;
 
         // Handle different custom field types
-        if (field.type === 'drop_down' && typeof field.value === 'number') {
+        if (field.type === "drop_down" && typeof field.value === "number") {
           // For dropdown fields, find the selected option
-          const selectedOption = field.type_config?.options?.find((opt: any) => opt.orderindex === field.value);
+          const selectedOption = field.type_config?.options?.find(
+            (opt: any) => opt.orderindex === field.value,
+          );
           fieldValue = selectedOption?.name || field.value;
         } else if (Array.isArray(field.value)) {
           // For multi-select or array values
-          fieldValue = field.value.map((v: any) => v.name || v).join(', ');
-        } else if (typeof field.value === 'object') {
+          fieldValue = field.value.map((v: any) => v.name || v).join(", ");
+        } else if (typeof field.value === "object") {
           // For object values (like users), extract meaningful data
-          fieldValue = field.value.username || field.value.name || JSON.stringify(field.value);
+          fieldValue =
+            field.value.username ||
+            field.value.name ||
+            JSON.stringify(field.value);
         }
 
         metadataLines.push(`custom_${fieldName}: ${fieldValue}`);


### PR DESCRIPTION
## Add `getTaskByCustomId` tool

> Alternative to #15 — that PR didn't work for me, so I implemented my own approach.

### Summary

Adds a dedicated `getTaskByCustomId` tool to fetch ClickUp tasks by their human-readable custom task ID (e.g. `PREFIX-123`) instead of the internal alphanumeric task ID.

Unlike #15, which modifies the existing `getTaskById` to auto-detect both ID formats, this PR adds a **separate, explicit tool** for custom IDs. This keeps the two use cases distinct and avoids ambiguity in validation logic.

### Changes

- **New tool `getTaskByCustomId`** in task-tools.ts
  - Accepts a `customId` string (e.g. `PREFIX-123`)
  - Calls `loadTaskContent` with `customTaskIds: true` to resolve the real internal task ID
  - Fetches comments and status history using the resolved ID
  - Returns full task context: details, comments, status history, and inline images
- **Refactored `loadTaskContent`** to return `{ contentBlocks, realTaskId }` so the resolved ID is available for follow-up API calls
- **Added manifest entry** for `getTaskByCustomId`
- **Added tests** in getTaskByCustomId.test.ts
- **Updated README and CHANGELOG**

### Testing

```bash
npm run test
npm run cli getTaskByCustomId customId="PREFIX-123"
```