### PR TITLE
fix: accept 10+ char and custom task IDs (drop the brittle 6-9 length cap)

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -4,12 +4,15 @@ import Fuse from 'fuse.js';
 const GLOBAL_REFRESH_INTERVAL = 60000; // 60 seconds - that is the rate limit time frame
 
 /**
- * Checks if a string looks like a valid ClickUp task ID
- * Valid task IDs are 6-9 characters long and contain only alphanumeric characters
+ * Checks if a string looks like a valid ClickUp task ID (search heuristic).
+ * Two shapes: default IDs (alphanumeric, 6+ chars - covers 9, 10, 11+ as ClickUp grows)
+ * and custom IDs (a letter-led prefix, a hyphen, then digits, e.g. "GH-123").
+ * Kept deliberately selective so the search-tools direct-fetch path isn't triggered
+ * by ordinary hyphenated terms like "follow-up".
  */
 export function isTaskId(str: string): boolean {
-  // Task IDs are 6-9 characters long and contain only alphanumeric characters
-  return /^[a-z0-9]{6,9}$/i.test(str);
+  // Default IDs: 6+ alphanumeric. Custom IDs: PREFIX-<digits>.
+  return /^([a-z0-9]{6,}|[a-z][a-z0-9]*-\d+)$/i.test(str);
 }
 
 // Cache for current user info to avoid repeated API calls and race conditions

--- a/src/tests/isTaskId.test.ts
+++ b/src/tests/isTaskId.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// config.ts reads env at import time; isTaskId lives in the same module.
+process.env.CLICKUP_API_KEY = "test-key";
+process.env.CLICKUP_TEAM_ID = "team1";
+
+test("isTaskId accepts default IDs of any modern length and custom IDs", async () => {
+  const { isTaskId } = await import("../shared/utils");
+
+  // Default IDs: ClickUp grows the length over time (9 -> 10 -> 11+).
+  for (const id of ["abcdef", "86ahzfw4z", "wdrv93ebwx", "wdrv93ebwf", "a1b2c3d4e5f6"]) {
+    assert.equal(isTaskId(id), true, `expected default ID to be accepted: ${id}`);
+  }
+
+  // Custom IDs: a letter-led prefix, a hyphen, then digits.
+  for (const id of ["GH-123", "PROJ-1234", "AB-1", "gh-99"]) {
+    assert.equal(isTaskId(id), true, `expected custom ID to be accepted: ${id}`);
+  }
+});
+
+test("isTaskId stays selective: ordinary terms are not mistaken for IDs", async () => {
+  const { isTaskId } = await import("../shared/utils");
+
+  // Hyphenated words must NOT match the custom-ID branch (no digit suffix) so the
+  // search-tools direct-fetch fallback isn't triggered for normal search terms.
+  for (const term of ["follow-up", "to-do", "re-run", "wip-task", "note-x"]) {
+    assert.equal(isTaskId(term), false, `expected hyphenated term to be rejected: ${term}`);
+  }
+
+  // Below the 6-char floor.
+  for (const term of ["abc", "task", "wip", "id"]) {
+    assert.equal(isTaskId(term), false, `expected sub-floor term to be rejected: ${term}`);
+  }
+});

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -19,13 +19,11 @@ export function registerTaskToolsRead(server: McpServer, userData: any) {
     {
       id: z
         .string()
-        .min(6)
-        .max(9)
         .refine(val => isTaskId(val), {
-          message: "Task ID must be 6-9 alphanumeric characters only"
+          message: "Task ID must be alphanumeric (e.g. a 9-10 char ID) or a custom ID like 'PREFIX-123'"
         })
         .describe(
-          `The 6-9 character ID of the task to get without a prefix like "#", "CU-" or "https://app.clickup.com/t/"`
+          `The ID of the task to get without a prefix like "#", "CU-" or "https://app.clickup.com/t/"`
         ),
     },
     {

--- a/src/tools/task-write-tools.ts
+++ b/src/tools/task-write-tools.ts
@@ -35,7 +35,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
       return descriptionBase.join("\n");
     })(),
     {
-      task_id: z.string().min(6).max(9).describe("The 6-9 character task ID to comment on"),
+      task_id: z.string().describe("The task ID to comment on (validated by the ClickUp API)"),
       comment: z.string().min(1).describe("The comment text to add to the task"),
     },
     {
@@ -122,7 +122,7 @@ export function registerTaskToolsWrite(server: McpServer, userData: any) {
       return descriptionBase.join("\n");
     })(),
     {
-      task_id: z.string().min(6).max(9).describe("The 6-9 character task ID to update"),
+      task_id: z.string().describe("The task ID to update (validated by the ClickUp API)"),
       name: taskNameSchema.optional(),
       append_description: z.string().optional().describe("Optional markdown content to APPEND to existing task description (preserves existing content for safety)"),
       status: z.string().optional().describe("Optional new status name - use getListInfo to see valid options"),

--- a/src/tools/time-tools.ts
+++ b/src/tools/time-tools.ts
@@ -60,7 +60,7 @@ export function registerTimeToolsRead(server: McpServer) {
     "getTimeEntries",
     "Gets time entries for a specific task or all user's time entries. Returns last 30 days by default if no dates specified.",
     {
-      task_id: z.string().min(6).max(9).optional().describe("Optional 6-9 character task ID to filter entries. If not provided, returns all user's time entries."),
+      task_id: z.string().optional().describe("Optional task ID to filter entries. If not provided, returns all user's time entries."),
       start_date: z.string().optional().describe("Optional start date filter as ISO date string (e.g., '2024-10-06T00:00:00+02:00'). Defaults to 30 days ago."),
       end_date: z.string().optional().describe("Optional end date filter as ISO date string (e.g., '2024-10-06T23:59:59+02:00'). Defaults to current date."),
       list_id: z.string().optional().describe("Optional single list ID to filter time entries by a specific list"),
@@ -330,7 +330,7 @@ export function registerTimeToolsWrite(server: McpServer) {
       "Suggest moving the task to an active status like 'in progress' first."
     ].join("\n"),
     {
-      task_id: z.string().min(6).max(9).describe("The 6-9 character task ID to book time against"),
+      task_id: z.string().describe("The task ID to book time against (validated by the ClickUp API)"),
       hours: z.number().min(0.01).max(24).describe("Hours to book (decimal format, e.g., 0.25 = 15min, 1.5 = 1h 30min)"),
       description: z.string().optional().describe("Optional description for the time entry"),
       start_time: z.string().optional().describe("Optional start time as ISO date string (e.g., '2024-10-06T09:00:00+02:00', defaults to current time)")


### PR DESCRIPTION
## Problem

ClickUp has started issuing 10-character task IDs (e.g. `wdrv93ebwx`), and many workspaces use custom task IDs (`PREFIX-123`). The current client-side validation hard-codes a 6-9 character alphanumeric cap, so every tool that takes a task ID rejects these *before* the request ever reaches the ClickUp API:

- `getTaskById` — `id: z.string().min(6).max(9).refine(isTaskId)`
- `updateTask` and `addComment` — `task_id: z.string().min(6).max(9)` (the painful ones: you cannot move status or comment on a 10-char task)
- `getTimeEntries` / `createTimeEntry` — same cap on `task_id`
- `isTaskId()` — regex `^[a-z0-9]{6,9}$` (shared; also used by the search fallback)

Because the MCP exposes the cap in the tool input schema (`maxLength: 9`), an MCP client is blocked at the schema layer and the call never runs.

## Change

Let the ClickUp API be the authority for ID validity, and keep `isTaskId()` only where it is genuinely a heuristic.

- Drop `.min(6).max(9)` from the five explicit task-ID input schemas (`getTaskById`, `addComment`, `updateTask`, `getTimeEntries`, `createTimeEntry`). The API already returns a clear error for an unknown/invalid ID.
- Broaden `isTaskId()` (the search-fallback heuristic in `search-tools.ts`) to match both shapes:
  - default IDs: `[a-z0-9]{6,}` — no upper bound, so it survives ClickUp growing IDs to 10, 11, ...
  - custom IDs: `[a-z][a-z0-9]*-\d+` — a letter-led prefix, a hyphen, then digits (e.g. `GH-123`).

  It stays deliberately selective: the custom branch requires a digit suffix, so ordinary hyphenated search terms (`follow-up`, `to-do`) are not mistaken for IDs and do not trigger a needless direct fetch in the search fallback.

## Blast radius

`isTaskId` has two consumers: `getTaskById`'s `.refine` and `search-tools.ts`'s `terms.filter(isTaskId)`. Both were reviewed. The broadened heuristic resolves longer/custom IDs in the search fallback and is graceful on a miss (the existing code already ignores non-OK direct fetches).

## Tests

Adds `src/tests/isTaskId.test.ts` (accepts 9/10/12-char default IDs and custom IDs; rejects hyphenated words and sub-floor terms). `npm test` is green (33 tests).

> Note: custom IDs are now accepted by the schema, but end-to-end resolution of a custom ID via `getTaskById` still depends on the ClickUp `custom_task_ids` / `team_id` query params, which is out of scope for this change.
